### PR TITLE
add new user.set hook

### DIFF
--- a/resources/js/Workspace.js
+++ b/resources/js/Workspace.js
@@ -38,6 +38,11 @@ export default class Workspace {
         this.channel.here(users => {
             this.subscribeToVuexMutations();
             Statamic.$store.commit(`collaboration/${this.channelName}/setUsers`, users);
+
+            Statamic.$hooks.run('user.set', {
+                collection: this.container.blueprint,
+                users: users,
+            });
         });
 
         this.channel.joining(user => {


### PR DESCRIPTION
We need this hook to detect that more than one user wants to edit an entry. In our case, we trigger a blocking notification afterwards.