### PR TITLE
update lastValues and lastMetaValues on initalization

### DIFF
--- a/resources/js/Workspace.js
+++ b/resources/js/Workspace.js
@@ -431,7 +431,7 @@ export default class Workspace {
     }
 
     initializeValuesAndMeta() {
-        this.lastValues = Statamic.$store.state.publish[this.container.name].values;
-        this.lastMetaValues = Statamic.$store.state.publish[this.container.name].meta;
+        this.lastValues = clone(Statamic.$store.state.publish[this.container.name].values);
+        this.lastMetaValues = clone(Statamic.$store.state.publish[this.container.name].meta);
     }
 }


### PR DESCRIPTION
So that `lastValues` and `lastMetaValues` have the correct values we had to clone them once during initialization.