### PR TITLE
support mutiple sessions per user

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 SPIEGEL Tech Lab GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/resources/js/StatusBar.vue
+++ b/resources/js/StatusBar.vue
@@ -5,16 +5,16 @@
         <div v-if="users.length > 1" class="flex items-center">
             <div
                 v-for="user in users"
-                :key="user.id"
+                :key="user.info.id"
             >
                 <dropdown-list>
                     <template v-slot:trigger>
                         <avatar
-                            :user="user"
+                            :user="user.info"
                             class="rounded-full w-6 h-6 mr-1 cursor-pointer text-xs"
                         />
                     </template>
-                    <dropdown-item text="Unlock" @click="$emit('unlock', user)" />
+                    <dropdown-item text="Unlock" @click="$emit('unlock', user.info.id)" />
                 </dropdown-list>
             </div>
         </div>
@@ -32,12 +32,20 @@ export default {
         channelName: {
             type: String,
             required: true,
-        }
+        },
     },
 
     computed: {
         users() {
-            return this.$store.state.collaboration[this.channelName].users;
+            if (!this.$store.state.collaboration[this.channelName].users)
+                return [];
+
+            // show distinct users (a user can be connected from multiple tabs/windows/machines)
+            return _.uniq(
+                this.$store.state.collaboration[this.channelName].users,
+                false,
+                (u) => u.info.id
+            );
         },
         connecting() {
             return this.users.length === 0;


### PR DESCRIPTION
This PR adds ~two~ one feature:
- the same user can edit an entry from two tabs/windows/machines and has her changes synchronised between all her sessions (as well as with other user's changes)
- ~lock/unlock support for individual Replicator sets instead of the entire field (in conjunction with the patch from https://github.com/sauerbraten/cms/commit/891bcc6fe03ea68f2f2b38e3e569b0a1d9f13cc1)~

### Multiple Sessions Support

In order to sync changes between two sessions of the same user, each session must act as a separate Echo user. (Pusher does not play back events triggered by A to any of A's connections.) To pretend to Echo/Pusher that each session is a different user, we have a custom User and UserRepository class:

```php
<?php

namespace App\Polygon\Auth;

use Statamic\Auth\File\User as StatamicUser;

class User extends StatamicUser
{
    public function getAuthIdentifierForBroadcasting()
    {
        if (request()->socket_id) {
            return parent::getAuthIdentifier() . '#' . request()->socket_id;
        }
        return parent::getAuthIdentifier();
    }
}
```

```php
<?php

namespace App\Polygon\Auth;

use Statamic\Stache\Repositories\UserRepository as StatamicUserRepository;
use Statamic\Contracts\Auth\User as UserContract;

class UserRepository extends StatamicUserRepository
{
    public function make(): UserContract
    {
        return new User();
    }
}
```

Laravel Echo calls getAuthIdentifierForBroadcasting() if present on the user object it sees, and we include Pusher's socket_id in the ID used for broadcasting. That way, Pusher treats all websocket connections as different members of the presence channel and broadcasts changes between all of them.

In order to access the socket ID of the author of a channel event, it's necessary to use Echo's on() method with Pusher-specific event names instead of the more abstract here(), joining() or leaving() functions Echo provides.

As a rule of thumb, if `user` is the callback argument to a 'pusher:*' event:
- `user.id` is the Echo broadcasting ID (i.e. contains the Pusher socket ID and is unique for each websocket),
- `user.info` is what collaboration's Broadcast::channel() callback returns (i.e. what the corresponding here()/joining()/leaving() callback would have gotten as its argument), and
- `user.info.id` is the Statamic user ID (i.e. is the same for every session belonging to the same Statamic user).

Also, while collaboration sent the entire Statamic user object with each message before, now only the Pusher member ID (= Echo broadcasting ID) is sent, and clients resolve that ID locally in the user data they received when joining the channel.

**Note**: this solution works well with Pusher, but is untested and might break with any other Laravel broadcasting provider!

### ~Set-level locking in Replicator~

~While the core patch (https://github.com/sauerbraten/cms/commit/891bcc6fe03ea68f2f2b38e3e569b0a1d9f13cc1) has most of the magic, collaboration needs to support the new Pusher events 'focus-set' and 'blur-set' as well as the Vuex mutations 'lockReplicatorSet' and 'unlockReplicatorSet'.~