### PR TITLE
Support Statamic 3.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "Collaboration tools for Statamic 3",
     "license": "proprietary",
     "require": {
-        "statamic/cms": "3.1.* || 3.2.*",
+        "statamic/cms": "3.1.* || 3.2.* || 3.3.*",
         "pixelfear/composer-dist-plugin": "^0.1.4"
     },
     "extra": {


### PR DESCRIPTION
Relax version constraints to allow Statamic v3.3.

Fixes #59 