### PR TITLE
Fix channel names for terms with multiple `::` separators

### DIFF
--- a/resources/js/Workspace.js
+++ b/resources/js/Workspace.js
@@ -32,7 +32,7 @@ export default class Workspace {
     }
 
     initializeEcho() {
-        const reference = this.container.reference.replace('::', '.');
+        const reference = this.container.reference.replaceAll('::', '.');
         this.channelName = `${reference}.${this.container.site}`;
         this.channel = this.echo.join(this.channelName);
 


### PR DESCRIPTION
Actually on Workspace when the channel name is built there is a replace which replaces first occurrence of `::` with a `.`.
Pusher does not allow names with `::` so method `replace` is adjusted to `replaceAll` so it replace all occurrences.

Example channel name generated from terms: `presence-term.ad::test-slug::default.default`