### PR TITLE
Ability to disable sound effects

### DIFF
--- a/config/collaboration.php
+++ b/config/collaboration.php
@@ -1,0 +1,17 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Sound Effects
+    |--------------------------------------------------------------------------
+    |
+    | This determines whether or not the open sound effects are played when a
+    | user joins or leaves a room.
+    |
+    */
+
+    'sound_effects' => false,
+
+];

--- a/resources/js/Workspace.js
+++ b/resources/js/Workspace.js
@@ -52,14 +52,20 @@ export default class Workspace {
                 meta: this.cleanEntireMetaPayload(Statamic.$store.state.publish[this.container.name].meta),
                 focus: Statamic.$store.state.collaboration[this.channelName].focus,
             });
-            this.playAudio('buddy-in');
+
+            if (Statamic.$config.get('collaboration.sound_effects')) {
+                this.playAudio('buddy-in');
+            }
         });
 
         this.channel.leaving(user => {
             Statamic.$store.commit(`collaboration/${this.channelName}/removeUser`, user);
             Statamic.$toast.success(`${user.name} has left.`);
             this.blurAndUnlock(user);
-            this.playAudio('buddy-out');
+
+            if (Statamic.$config.get('collaboration.sound_effects')) {
+                this.playAudio('buddy-out');
+            }
         });
 
         this.listenForWhisper('updated', e => {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -5,6 +5,7 @@ namespace Statamic\Collaboration;
 use Illuminate\Support\Facades\Broadcast;
 use Statamic\Facades\User;
 use Statamic\Providers\AddonServiceProvider;
+use Statamic\Statamic;
 
 class ServiceProvider extends AddonServiceProvider
 {
@@ -14,13 +15,13 @@ class ServiceProvider extends AddonServiceProvider
         'hotFile' => __DIR__.'/../resources/dist/hot',
     ];
 
-    public function boot()
+    public function bootAddon()
     {
-        parent::boot();
+        Statamic::provideToScript(['collaboration' => config('collaboration')]);
 
         Broadcast::channel('entry.{id}.{site}', function ($user, $id, $site) {
             $user = User::fromUser($user);
-            
+
             return [
                 'name' => $user->name(),
                 'id' => $user->id(),


### PR DESCRIPTION
This pull request makes it possible to disable the "door open and door close" sound effects when users join/leave rooms. 

This PR adds a new `collaboration` config file which will be automatically published upon install by Statamic's `AddonServiceProvider`. The setting defaults to `true`. 

Closes #63.