### PR TITLE
Use `ubuntu-latest` in GitHub Actions workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v1


### PR DESCRIPTION
GitHub are deprecating `ubuntu-20.04` in GitHub Actions, so this pull request updates our workflows using it to use `ubuntu-latest` instead.

![CleanShot 2025-02-11 at 17 38 11](https://github.com/user-attachments/assets/26db12e4-11f6-4915-9396-fc87c2f01c7b)
