### PR TITLE
Use the Authentication Guard that is defined in the users config file.

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -30,10 +30,6 @@ class ServiceProvider extends AddonServiceProvider
                 'avatar' => $user->avatar(),
                 'initials' => $user->initials(),
             ];
-        }, [
-            'guards' => [
-                config('statamic.users.guards.cp'),
-            ],
-        ]);
+        }, ['guards' => [config('statamic.users.guards.cp')]]);
     }
 }


### PR DESCRIPTION
When you customise the Authentication Guards the collaboration plugin fails to load correctly and continues to show the message "Attempting websocket connection..."

![Screenshot 2025-06-27 at 16 33 55](https://github.com/user-attachments/assets/bcfdae79-a61b-4bd9-9a3e-9c916bd6913e)

This happens because the POST request to `/broadcasting/auth` fails with a 403 error.

![Screenshot 2025-06-27 at 16 27 29](https://github.com/user-attachments/assets/6b2f309f-6e52-4387-a9d0-99d0a3d6155f)

By updating the channel to be aware of the guards that are defined in the users config file, the user is able to authenticate correctly and the collaboration plugin connection works again.

![Screenshot 2025-06-27 at 16 32 29](https://github.com/user-attachments/assets/9967e9c5-0921-4e9d-b7fc-76bec24005cb)

This example is from the docs for [Using an Independent Authentication Guard](https://statamic.dev/tips/using-an-independent-authentication-guard). If you use a custom guard as this tutorial in the documentation describes then the collaboration plugin doesn't work anymore.

```php
// config/statamic/users.php
 
'guards' => [
    'cp' => 'statamic',
    'web' => 'web',
],
```

While the [default config](https://github.com/statamic/cms/blob/3b73a795a10900a7a2a1a6748b0383faa5e1b230/config/users.php#L151) is to use the `web` authentication guard 

```php
    'guards' => [
        'cp' => 'web',
        'web' => 'web',
    ],
```

Closes #106 