### PR TITLE
Statamic 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@
 > Real-time collaboration and multi-user authoring for Statamic Pro.
 <!-- /statamic:hide -->
 
-> [!NOTE]  
-> This addon hasn't been updated for Statamic 6 yet. We're planning to tackle it soon, but don't have a firm ETA.
-
 ## Features
 
 - Presence indicators when multiple people have the same entry opened.

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "description": "Real-time collaboration and multi-user authoring for Statamic Pro.",
     "license": "proprietary",
     "require": {
-        "statamic/cms": "^5.0",
-        "pixelfear/composer-dist-plugin": "^0.1.4"
+        "statamic/cms": "^6.0",
+        "pixelfear/composer-dist-plugin": "^0.1.6"
     },
     "extra": {
         "laravel": {
@@ -25,6 +25,11 @@
     "autoload": {
         "psr-4": {
             "Statamic\\Collaboration\\": "src"
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "pixelfear/composer-dist-plugin": true
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,18 +5,40 @@
     "packages": {
         "": {
             "dependencies": {
-                "vue": "^2.6.11"
+                "vue": "^3.4.27"
             },
             "devDependencies": {
-                "@vitejs/plugin-vue2": "^2.2.0",
-                "laravel-vite-plugin": "^0.7.2",
-                "vite": "^4.5.2"
+                "@statamic/cms": "file:./vendor/statamic/cms/resources/dist-package",
+                "laravel-vite-plugin": "^2.0.0",
+                "vite": "^7.0.4"
+            }
+        },
+        "node_modules/@babel/helper-string-parser": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-validator-identifier": {
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+            "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.5.tgz",
-            "integrity": "sha512-DFZMC9LJUG9PLOclRC32G63UXwzqS2koQC8dkx+PLdmt1xSePYpbT/NbsrJy8Q/muXz7o/h/d4A7Fuyixm559Q==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+            "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.29.0"
+            },
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
@@ -24,421 +46,1034 @@
                 "node": ">=6.0.0"
             }
         },
-        "node_modules/@esbuild/android-arm": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
-            "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "android"
-            ],
+        "node_modules/@babel/types": {
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.28.5"
+            },
             "engines": {
-                "node": ">=12"
+                "node": ">=6.9.0"
             }
         },
-        "node_modules/@esbuild/android-arm64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
-            "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/android-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
-            "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
-            "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/darwin-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
-            "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
-            "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
-            "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/linux-arm": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
-            "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/linux-arm64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
-            "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/linux-ia32": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
-            "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/linux-loong64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
-            "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
-            "cpu": [
-                "loong64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
-            "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
-            "cpu": [
-                "mips64el"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
-            "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+        "node_modules/@esbuild/aix-ppc64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+            "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
             "cpu": [
                 "ppc64"
             ],
             "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+            "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+            "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-x64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+            "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/darwin-arm64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+            "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/darwin-x64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+            "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+            "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-x64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+            "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+            "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+            "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ia32": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+            "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+            "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-mips64el": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+            "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ppc64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+            "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
-            "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+            "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
             "cpu": [
                 "riscv64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
-            "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+            "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
             "cpu": [
                 "s390x"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
-            "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+            "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
-        "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
-            "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+        "node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+            "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
             "cpu": [
-                "x64"
+                "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "netbsd"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
-        "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
-            "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+        "node_modules/@esbuild/netbsd-x64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+            "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+            "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "openbsd"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
-        "node_modules/@esbuild/sunos-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
-            "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+        "node_modules/@esbuild/openbsd-x64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+            "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+            "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/sunos-x64": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+            "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "sunos"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
-            "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+            "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
-            "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+            "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
             "cpu": [
                 "ia32"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
-            "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+            "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
-        "node_modules/@vitejs/plugin-vue2": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue2/-/plugin-vue2-2.2.0.tgz",
-            "integrity": "sha512-1km7zEuZ/9QRPvzXSjikbTYGQPG86Mq1baktpC4sXqsXlb02HQKfi+fl8qVS703JM7cgm24Ga9j+RwKmvFn90A==",
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+            "license": "MIT"
+        },
+        "node_modules/@rolldown/pluginutils": {
+            "version": "1.0.0-rc.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.2.tgz",
+            "integrity": "sha512-izyXV/v+cHiRfozX62W9htOAvwMo4/bXKDrQ+vom1L1qRuexPock/7VZDAhnpHCLNejd3NJ6hiab+tO0D44Rgw==",
             "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@rollup/rollup-android-arm-eabi": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
+            "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-android-arm64": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
+            "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-arm64": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
+            "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-x64": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
+            "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-arm64": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
+            "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-x64": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
+            "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
+            "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
+            "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-gnu": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
+            "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-musl": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
+            "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-loong64-gnu": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
+            "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-loong64-musl": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
+            "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
+            "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-musl": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
+            "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
+            "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-musl": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
+            "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-s390x-gnu": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
+            "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-gnu": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+            "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-musl": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+            "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-openbsd-x64": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
+            "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-openharmony-arm64": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
+            "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-arm64-msvc": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
+            "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-ia32-msvc": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
+            "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-gnu": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
+            "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-msvc": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
+            "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@statamic/cms": {
+            "resolved": "vendor/statamic/cms/resources/dist-package",
+            "link": true
+        },
+        "node_modules/@types/estree": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+            "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@vitejs/plugin-vue": {
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.4.tgz",
+            "integrity": "sha512-uM5iXipgYIn13UUQCZNdWkYk+sysBeA97d5mHsAoAt1u/wpN3+zxOmsVJWosuzX+IMGRzeYUNytztrYznboIkQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@rolldown/pluginutils": "1.0.0-rc.2"
+            },
             "engines": {
-                "node": "^14.18.0 || >= 16.0.0"
+                "node": "^20.19.0 || >=22.12.0"
             },
             "peerDependencies": {
-                "vite": "^3.0.0 || ^4.0.0",
-                "vue": "^2.7.0-0"
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0",
+                "vue": "^3.2.25"
+            }
+        },
+        "node_modules/@vue/compiler-core": {
+            "version": "3.5.28",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.28.tgz",
+            "integrity": "sha512-kviccYxTgoE8n6OCw96BNdYlBg2GOWfBuOW4Vqwrt7mSKWKwFVvI8egdTltqRgITGPsTFYtKYfxIG8ptX2PJHQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.29.0",
+                "@vue/shared": "3.5.28",
+                "entities": "^7.0.1",
+                "estree-walker": "^2.0.2",
+                "source-map-js": "^1.2.1"
+            }
+        },
+        "node_modules/@vue/compiler-dom": {
+            "version": "3.5.28",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.28.tgz",
+            "integrity": "sha512-/1ZepxAb159jKR1btkefDP+J2xuWL5V3WtleRmxaT+K2Aqiek/Ab/+Ebrw2pPj0sdHO8ViAyyJWfhXXOP/+LQA==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/compiler-core": "3.5.28",
+                "@vue/shared": "3.5.28"
             }
         },
         "node_modules/@vue/compiler-sfc": {
-            "version": "2.7.14",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.14.tgz",
-            "integrity": "sha512-aNmNHyLPsw+sVvlQFQ2/8sjNuLtK54TC6cuKnVzAY93ks4ZBrvwQSnkkIh7bsbNhum5hJBS00wSDipQ937f5DA==",
+            "version": "3.5.28",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.28.tgz",
+            "integrity": "sha512-6TnKMiNkd6u6VeVDhZn/07KhEZuBSn43Wd2No5zaP5s3xm8IqFTHBj84HJah4UepSUJTro5SoqqlOY22FKY96g==",
+            "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.18.4",
-                "postcss": "^8.4.14",
-                "source-map": "^0.6.1"
+                "@babel/parser": "^7.29.0",
+                "@vue/compiler-core": "3.5.28",
+                "@vue/compiler-dom": "3.5.28",
+                "@vue/compiler-ssr": "3.5.28",
+                "@vue/shared": "3.5.28",
+                "estree-walker": "^2.0.2",
+                "magic-string": "^0.30.21",
+                "postcss": "^8.5.6",
+                "source-map-js": "^1.2.1"
             }
         },
+        "node_modules/@vue/compiler-ssr": {
+            "version": "3.5.28",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.28.tgz",
+            "integrity": "sha512-JCq//9w1qmC6UGLWJX7RXzrGpKkroubey/ZFqTpvEIDJEKGgntuDMqkuWiZvzTzTA5h2qZvFBFHY7fAAa9475g==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/compiler-dom": "3.5.28",
+                "@vue/shared": "3.5.28"
+            }
+        },
+        "node_modules/@vue/reactivity": {
+            "version": "3.5.28",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.28.tgz",
+            "integrity": "sha512-gr5hEsxvn+RNyu9/9o1WtdYdwDjg5FgjUSBEkZWqgTKlo/fvwZ2+8W6AfKsc9YN2k/+iHYdS9vZYAhpi10kNaw==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/shared": "3.5.28"
+            }
+        },
+        "node_modules/@vue/runtime-core": {
+            "version": "3.5.28",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.28.tgz",
+            "integrity": "sha512-POVHTdbgnrBBIpnbYU4y7pOMNlPn2QVxVzkvEA2pEgvzbelQq4ZOUxbp2oiyo+BOtiYlm8Q44wShHJoBvDPAjQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/reactivity": "3.5.28",
+                "@vue/shared": "3.5.28"
+            }
+        },
+        "node_modules/@vue/runtime-dom": {
+            "version": "3.5.28",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.28.tgz",
+            "integrity": "sha512-4SXxSF8SXYMuhAIkT+eBRqOkWEfPu6nhccrzrkioA6l0boiq7sp18HCOov9qWJA5HML61kW8p/cB4MmBiG9dSA==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/reactivity": "3.5.28",
+                "@vue/runtime-core": "3.5.28",
+                "@vue/shared": "3.5.28",
+                "csstype": "^3.2.3"
+            }
+        },
+        "node_modules/@vue/server-renderer": {
+            "version": "3.5.28",
+            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.28.tgz",
+            "integrity": "sha512-pf+5ECKGj8fX95bNincbzJ6yp6nyzuLDhYZCeFxUNp8EBrQpPpQaLX3nNCp49+UbgbPun3CeVE+5CXVV1Xydfg==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/compiler-ssr": "3.5.28",
+                "@vue/shared": "3.5.28"
+            },
+            "peerDependencies": {
+                "vue": "3.5.28"
+            }
+        },
+        "node_modules/@vue/shared": {
+            "version": "3.5.28",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.28.tgz",
+            "integrity": "sha512-cfWa1fCGBxrvaHRhvV3Is0MgmrbSCxYTXCSCau2I0a1Xw1N1pHAvkWCiXPRAqjvToILvguNyEwjevUqAuBQWvQ==",
+            "license": "MIT"
+        },
         "node_modules/csstype": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-            "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+            "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+            "license": "MIT"
+        },
+        "node_modules/entities": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+            "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
         },
         "node_modules/esbuild": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
-            "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+            "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
             "dev": true,
             "hasInstallScript": true,
+            "license": "MIT",
             "bin": {
                 "esbuild": "bin/esbuild"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             },
             "optionalDependencies": {
-                "@esbuild/android-arm": "0.18.20",
-                "@esbuild/android-arm64": "0.18.20",
-                "@esbuild/android-x64": "0.18.20",
-                "@esbuild/darwin-arm64": "0.18.20",
-                "@esbuild/darwin-x64": "0.18.20",
-                "@esbuild/freebsd-arm64": "0.18.20",
-                "@esbuild/freebsd-x64": "0.18.20",
-                "@esbuild/linux-arm": "0.18.20",
-                "@esbuild/linux-arm64": "0.18.20",
-                "@esbuild/linux-ia32": "0.18.20",
-                "@esbuild/linux-loong64": "0.18.20",
-                "@esbuild/linux-mips64el": "0.18.20",
-                "@esbuild/linux-ppc64": "0.18.20",
-                "@esbuild/linux-riscv64": "0.18.20",
-                "@esbuild/linux-s390x": "0.18.20",
-                "@esbuild/linux-x64": "0.18.20",
-                "@esbuild/netbsd-x64": "0.18.20",
-                "@esbuild/openbsd-x64": "0.18.20",
-                "@esbuild/sunos-x64": "0.18.20",
-                "@esbuild/win32-arm64": "0.18.20",
-                "@esbuild/win32-ia32": "0.18.20",
-                "@esbuild/win32-x64": "0.18.20"
+                "@esbuild/aix-ppc64": "0.27.3",
+                "@esbuild/android-arm": "0.27.3",
+                "@esbuild/android-arm64": "0.27.3",
+                "@esbuild/android-x64": "0.27.3",
+                "@esbuild/darwin-arm64": "0.27.3",
+                "@esbuild/darwin-x64": "0.27.3",
+                "@esbuild/freebsd-arm64": "0.27.3",
+                "@esbuild/freebsd-x64": "0.27.3",
+                "@esbuild/linux-arm": "0.27.3",
+                "@esbuild/linux-arm64": "0.27.3",
+                "@esbuild/linux-ia32": "0.27.3",
+                "@esbuild/linux-loong64": "0.27.3",
+                "@esbuild/linux-mips64el": "0.27.3",
+                "@esbuild/linux-ppc64": "0.27.3",
+                "@esbuild/linux-riscv64": "0.27.3",
+                "@esbuild/linux-s390x": "0.27.3",
+                "@esbuild/linux-x64": "0.27.3",
+                "@esbuild/netbsd-arm64": "0.27.3",
+                "@esbuild/netbsd-x64": "0.27.3",
+                "@esbuild/openbsd-arm64": "0.27.3",
+                "@esbuild/openbsd-x64": "0.27.3",
+                "@esbuild/openharmony-arm64": "0.27.3",
+                "@esbuild/sunos-x64": "0.27.3",
+                "@esbuild/win32-arm64": "0.27.3",
+                "@esbuild/win32-ia32": "0.27.3",
+                "@esbuild/win32-x64": "0.27.3"
+            }
+        },
+        "node_modules/estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "license": "MIT"
+        },
+        "node_modules/fdir": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
             }
         },
         "node_modules/fsevents": {
@@ -447,6 +1082,7 @@
             "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
             "dev": true,
             "hasInstallScript": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
@@ -456,31 +1092,45 @@
             }
         },
         "node_modules/laravel-vite-plugin": {
-            "version": "0.7.8",
-            "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-0.7.8.tgz",
-            "integrity": "sha512-HWYqpQYHR3kEQ1LsHX7gHJoNNf0bz5z5mDaHBLzS+PGLCTmYqlU5/SZyeEgObV7z7bC/cnStYcY9H1DI1D5Udg==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-2.1.0.tgz",
+            "integrity": "sha512-z+ck2BSV6KWtYcoIzk9Y5+p4NEjqM+Y4i8/H+VZRLq0OgNjW2DqyADquwYu5j8qRvaXwzNmfCWl1KrMlV1zpsg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "picocolors": "^1.0.0",
-                "vite-plugin-full-reload": "^1.0.5"
+                "vite-plugin-full-reload": "^1.1.0"
+            },
+            "bin": {
+                "clean-orphaned-assets": "bin/clean.js"
             },
             "engines": {
-                "node": ">=14"
+                "node": "^20.19.0 || >=22.12.0"
             },
             "peerDependencies": {
-                "vite": "^3.0.0 || ^4.0.0"
+                "vite": "^7.0.0"
+            }
+        },
+        "node_modules/magic-string": {
+            "version": "0.30.21",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.5"
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-            "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+            "version": "3.3.11",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
             "funding": [
                 {
                     "type": "github",
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "MIT",
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
             },
@@ -489,26 +1139,28 @@
             }
         },
         "node_modules/picocolors": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
+            "license": "MIT",
             "engines": {
-                "node": ">=8.6"
+                "node": ">=12"
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/postcss": {
-            "version": "8.4.31",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-            "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+            "version": "8.5.6",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+            "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -523,80 +1175,131 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.6",
-                "picocolors": "^1.0.0",
-                "source-map-js": "^1.0.2"
+                "nanoid": "^3.3.11",
+                "picocolors": "^1.1.1",
+                "source-map-js": "^1.2.1"
             },
             "engines": {
                 "node": "^10 || ^12 || >=14"
             }
         },
         "node_modules/rollup": {
-            "version": "3.29.4",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
-            "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
+            "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
             "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "1.0.8"
+            },
             "bin": {
                 "rollup": "dist/bin/rollup"
             },
             "engines": {
-                "node": ">=14.18.0",
+                "node": ">=18.0.0",
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
+                "@rollup/rollup-android-arm-eabi": "4.57.1",
+                "@rollup/rollup-android-arm64": "4.57.1",
+                "@rollup/rollup-darwin-arm64": "4.57.1",
+                "@rollup/rollup-darwin-x64": "4.57.1",
+                "@rollup/rollup-freebsd-arm64": "4.57.1",
+                "@rollup/rollup-freebsd-x64": "4.57.1",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
+                "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
+                "@rollup/rollup-linux-arm64-gnu": "4.57.1",
+                "@rollup/rollup-linux-arm64-musl": "4.57.1",
+                "@rollup/rollup-linux-loong64-gnu": "4.57.1",
+                "@rollup/rollup-linux-loong64-musl": "4.57.1",
+                "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
+                "@rollup/rollup-linux-ppc64-musl": "4.57.1",
+                "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
+                "@rollup/rollup-linux-riscv64-musl": "4.57.1",
+                "@rollup/rollup-linux-s390x-gnu": "4.57.1",
+                "@rollup/rollup-linux-x64-gnu": "4.57.1",
+                "@rollup/rollup-linux-x64-musl": "4.57.1",
+                "@rollup/rollup-openbsd-x64": "4.57.1",
+                "@rollup/rollup-openharmony-arm64": "4.57.1",
+                "@rollup/rollup-win32-arm64-msvc": "4.57.1",
+                "@rollup/rollup-win32-ia32-msvc": "4.57.1",
+                "@rollup/rollup-win32-x64-gnu": "4.57.1",
+                "@rollup/rollup-win32-x64-msvc": "4.57.1",
                 "fsevents": "~2.3.2"
             }
         },
-        "node_modules/source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+        "node_modules/source-map-js": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/source-map-js": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-            "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+        "node_modules/tinyglobby": {
+            "version": "0.2.15",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.3"
+            },
             "engines": {
-                "node": ">=0.10.0"
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
             }
         },
         "node_modules/vite": {
-            "version": "4.5.2",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
-            "integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+            "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "esbuild": "^0.18.10",
-                "postcss": "^8.4.27",
-                "rollup": "^3.27.1"
+                "esbuild": "^0.27.0",
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.3",
+                "postcss": "^8.5.6",
+                "rollup": "^4.43.0",
+                "tinyglobby": "^0.2.15"
             },
             "bin": {
                 "vite": "bin/vite.js"
             },
             "engines": {
-                "node": "^14.18.0 || >=16.0.0"
+                "node": "^20.19.0 || >=22.12.0"
             },
             "funding": {
                 "url": "https://github.com/vitejs/vite?sponsor=1"
             },
             "optionalDependencies": {
-                "fsevents": "~2.3.2"
+                "fsevents": "~2.3.3"
             },
             "peerDependencies": {
-                "@types/node": ">= 14",
-                "less": "*",
+                "@types/node": "^20.19.0 || >=22.12.0",
+                "jiti": ">=1.21.0",
+                "less": "^4.0.0",
                 "lightningcss": "^1.21.0",
-                "sass": "*",
-                "stylus": "*",
-                "sugarss": "*",
-                "terser": "^5.4.0"
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
+                "terser": "^5.16.0",
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
             },
             "peerDependenciesMeta": {
                 "@types/node": {
+                    "optional": true
+                },
+                "jiti": {
                     "optional": true
                 },
                 "less": {
@@ -608,6 +1311,9 @@
                 "sass": {
                     "optional": true
                 },
+                "sass-embedded": {
+                    "optional": true
+                },
                 "stylus": {
                     "optional": true
                 },
@@ -616,29 +1322,66 @@
                 },
                 "terser": {
                     "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
+                    "optional": true
                 }
             }
         },
         "node_modules/vite-plugin-full-reload": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/vite-plugin-full-reload/-/vite-plugin-full-reload-1.0.5.tgz",
-            "integrity": "sha512-kVZFDFWr0DxiHn6MuDVTQf7gnWIdETGlZh0hvTiMXzRN80vgF4PKbONSq8U1d0WtHsKaFODTQgJeakLacoPZEQ==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/vite-plugin-full-reload/-/vite-plugin-full-reload-1.2.0.tgz",
+            "integrity": "sha512-kz18NW79x0IHbxRSHm0jttP4zoO9P9gXh+n6UTwlNKnviTTEpOlum6oS9SmecrTtSr+muHEn5TUuC75UovQzcA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "picocolors": "^1.0.0",
                 "picomatch": "^2.3.1"
+            }
+        },
+        "node_modules/vite-plugin-full-reload/node_modules/picomatch": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.6"
             },
-            "peerDependencies": {
-                "vite": "^2 || ^3 || ^4"
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/vue": {
-            "version": "2.7.14",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.14.tgz",
-            "integrity": "sha512-b2qkFyOM0kwqWFuQmgd4o+uHGU7T+2z3T+WQp8UBjADfEv2n4FEMffzBmCKNP0IGzOEEfYjvtcC62xaSKeQDrQ==",
+            "version": "3.5.28",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.28.tgz",
+            "integrity": "sha512-BRdrNfeoccSoIZeIhyPBfvWSLFP4q8J3u8Ju8Ug5vu3LdD+yTM13Sg4sKtljxozbnuMu1NB1X5HBHRYUzFocKg==",
+            "license": "MIT",
             "dependencies": {
-                "@vue/compiler-sfc": "2.7.14",
-                "csstype": "^3.1.0"
+                "@vue/compiler-dom": "3.5.28",
+                "@vue/compiler-sfc": "3.5.28",
+                "@vue/runtime-dom": "3.5.28",
+                "@vue/server-renderer": "3.5.28",
+                "@vue/shared": "3.5.28"
+            },
+            "peerDependencies": {
+                "typescript": "*"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "vendor/statamic/cms/resources/dist-package": {
+            "name": "@statamic/cms",
+            "version": "0.0.0",
+            "dev": true,
+            "dependencies": {
+                "@vitejs/plugin-vue": "^6.0.0"
             }
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1625,9 +1625,9 @@
             }
         },
         "node_modules/vite-plugin-full-reload/node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,13 +4,14 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "collaboration",
             "dependencies": {
                 "vue": "^3.4.27"
             },
             "devDependencies": {
                 "@statamic/cms": "file:./vendor/statamic/cms/resources/dist-package",
-                "laravel-vite-plugin": "^2.0.0",
-                "vite": "^7.0.4"
+                "laravel-vite-plugin": "^3.0.0",
+                "vite": "^8.0.0"
             }
         },
         "node_modules/@babel/helper-string-parser": {
@@ -59,6 +60,40 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/@emnapi/core": {
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+            "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.1",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/runtime": {
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+            "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+            "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/@esbuild/aix-ppc64": {
             "version": "0.27.3",
             "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
@@ -72,6 +107,7 @@
             "os": [
                 "aix"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -89,6 +125,7 @@
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -106,6 +143,7 @@
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -123,6 +161,7 @@
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -140,6 +179,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -157,6 +197,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -174,6 +215,7 @@
             "os": [
                 "freebsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -191,6 +233,7 @@
             "os": [
                 "freebsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -208,6 +251,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -225,6 +269,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -242,6 +287,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -259,6 +305,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -276,6 +323,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -293,6 +341,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -310,6 +359,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -327,6 +377,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -344,6 +395,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -361,6 +413,7 @@
             "os": [
                 "netbsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -378,6 +431,7 @@
             "os": [
                 "netbsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -395,6 +449,7 @@
             "os": [
                 "openbsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -412,6 +467,7 @@
             "os": [
                 "openbsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -429,6 +485,7 @@
             "os": [
                 "openharmony"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -446,6 +503,7 @@
             "os": [
                 "sunos"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -463,6 +521,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -480,6 +539,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -497,6 +557,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -507,31 +568,39 @@
             "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
             "license": "MIT"
         },
-        "node_modules/@rolldown/pluginutils": {
-            "version": "1.0.0-rc.2",
-            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.2.tgz",
-            "integrity": "sha512-izyXV/v+cHiRfozX62W9htOAvwMo4/bXKDrQ+vom1L1qRuexPock/7VZDAhnpHCLNejd3NJ6hiab+tO0D44Rgw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
-            "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
-            "cpu": [
-                "arm"
-            ],
+        "node_modules/@napi-rs/wasm-runtime": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+            "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "android"
-            ]
+            "dependencies": {
+                "@tybys/wasm-util": "^0.10.1"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "peerDependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1"
+            }
         },
-        "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
-            "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+        "node_modules/@oxc-project/types": {
+            "version": "0.124.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
+            "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            }
+        },
+        "node_modules/@rolldown/binding-android-arm64": {
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
+            "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
             "cpu": [
                 "arm64"
             ],
@@ -540,12 +609,15 @@
             "optional": true,
             "os": [
                 "android"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
-            "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+        "node_modules/@rolldown/binding-darwin-arm64": {
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
+            "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
             "cpu": [
                 "arm64"
             ],
@@ -554,12 +626,15 @@
             "optional": true,
             "os": [
                 "darwin"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
-            "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+        "node_modules/@rolldown/binding-darwin-x64": {
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
+            "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
             "cpu": [
                 "x64"
             ],
@@ -568,26 +643,15 @@
             "optional": true,
             "os": [
                 "darwin"
-            ]
-        },
-        "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
-            "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
-            "cpu": [
-                "arm64"
             ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ]
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
-            "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+        "node_modules/@rolldown/binding-freebsd-x64": {
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
+            "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
             "cpu": [
                 "x64"
             ],
@@ -596,12 +660,15 @@
             "optional": true,
             "os": [
                 "freebsd"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
-            "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+        "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
+            "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
             "cpu": [
                 "arm"
             ],
@@ -610,26 +677,15 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
-            "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
-            "cpu": [
-                "arm"
             ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
-            "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+        "node_modules/@rolldown/binding-linux-arm64-gnu": {
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
+            "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
             "cpu": [
                 "arm64"
             ],
@@ -638,12 +694,15 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
-            "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+        "node_modules/@rolldown/binding-linux-arm64-musl": {
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
+            "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
             "cpu": [
                 "arm64"
             ],
@@ -652,40 +711,15 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-loong64-gnu": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
-            "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
-            "cpu": [
-                "loong64"
             ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-loong64-musl": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
-            "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
-            "cpu": [
-                "loong64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
-            "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+        "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
+            "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -694,54 +728,15 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-ppc64-musl": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
-            "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
-            "cpu": [
-                "ppc64"
             ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
-            "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
-            "cpu": [
-                "riscv64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
-            "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
-            "cpu": [
-                "riscv64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
-            "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+        "node_modules/@rolldown/binding-linux-s390x-gnu": {
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
+            "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
             "cpu": [
                 "s390x"
             ],
@@ -750,12 +745,15 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
-            "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+        "node_modules/@rolldown/binding-linux-x64-gnu": {
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
+            "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
             "cpu": [
                 "x64"
             ],
@@ -764,12 +762,15 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
-            "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+        "node_modules/@rolldown/binding-linux-x64-musl": {
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
+            "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
             "cpu": [
                 "x64"
             ],
@@ -778,26 +779,15 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-openbsd-x64": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
-            "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
-            "cpu": [
-                "x64"
             ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openbsd"
-            ]
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-openharmony-arm64": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
-            "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+        "node_modules/@rolldown/binding-openharmony-arm64": {
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
+            "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
             "cpu": [
                 "arm64"
             ],
@@ -806,12 +796,34 @@
             "optional": true,
             "os": [
                 "openharmony"
-            ]
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
-            "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+        "node_modules/@rolldown/binding-wasm32-wasi": {
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
+            "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "1.9.2",
+                "@emnapi/runtime": "1.9.2",
+                "@napi-rs/wasm-runtime": "^1.1.3"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-arm64-msvc": {
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
+            "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
             "cpu": [
                 "arm64"
             ],
@@ -820,26 +832,15 @@
             "optional": true,
             "os": [
                 "win32"
-            ]
-        },
-        "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
-            "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
-            "cpu": [
-                "ia32"
             ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ]
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
         },
-        "node_modules/@rollup/rollup-win32-x64-gnu": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
-            "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+        "node_modules/@rolldown/binding-win32-x64-msvc": {
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
+            "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
             "cpu": [
                 "x64"
             ],
@@ -848,32 +849,32 @@
             "optional": true,
             "os": [
                 "win32"
-            ]
-        },
-        "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
-            "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
-            "cpu": [
-                "x64"
             ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/pluginutils": {
+            "version": "1.0.0-rc.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.2.tgz",
+            "integrity": "sha512-izyXV/v+cHiRfozX62W9htOAvwMo4/bXKDrQ+vom1L1qRuexPock/7VZDAhnpHCLNejd3NJ6hiab+tO0D44Rgw==",
             "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ]
+            "license": "MIT"
         },
         "node_modules/@statamic/cms": {
             "resolved": "vendor/statamic/cms/resources/dist-package",
             "link": true
         },
-        "node_modules/@types/estree": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-            "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+        "node_modules/@tybys/wasm-util": {
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+            "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
         },
         "node_modules/@vitejs/plugin-vue": {
             "version": "6.0.4",
@@ -998,6 +999,16 @@
             "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
             "license": "MIT"
         },
+        "node_modules/detect-libc": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/entities": {
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
@@ -1017,6 +1028,8 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -1092,13 +1105,14 @@
             }
         },
         "node_modules/laravel-vite-plugin": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-2.1.0.tgz",
-            "integrity": "sha512-z+ck2BSV6KWtYcoIzk9Y5+p4NEjqM+Y4i8/H+VZRLq0OgNjW2DqyADquwYu5j8qRvaXwzNmfCWl1KrMlV1zpsg==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-3.0.1.tgz",
+            "integrity": "sha512-Bx8sVcLIaZT1d0eisABcmjQ1GZdJpaXcV66A8RhXGp9JgR3iL8jDnvakVDXuH87Tn5S9KNx3VOhmJZW1CSexOg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "picocolors": "^1.0.0",
+                "tinyglobby": "^0.2.12",
                 "vite-plugin-full-reload": "^1.1.0"
             },
             "bin": {
@@ -1108,7 +1122,268 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "peerDependencies": {
-                "vite": "^7.0.0"
+                "vite": "^8.0.0"
+            }
+        },
+        "node_modules/lightningcss": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+            "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "dependencies": {
+                "detect-libc": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "lightningcss-android-arm64": "1.32.0",
+                "lightningcss-darwin-arm64": "1.32.0",
+                "lightningcss-darwin-x64": "1.32.0",
+                "lightningcss-freebsd-x64": "1.32.0",
+                "lightningcss-linux-arm-gnueabihf": "1.32.0",
+                "lightningcss-linux-arm64-gnu": "1.32.0",
+                "lightningcss-linux-arm64-musl": "1.32.0",
+                "lightningcss-linux-x64-gnu": "1.32.0",
+                "lightningcss-linux-x64-musl": "1.32.0",
+                "lightningcss-win32-arm64-msvc": "1.32.0",
+                "lightningcss-win32-x64-msvc": "1.32.0"
+            }
+        },
+        "node_modules/lightningcss-android-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+            "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+            "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+            "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-freebsd-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+            "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm-gnueabihf": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+            "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+            "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+            "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+            "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+            "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-arm64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+            "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-x64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+            "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
             }
         },
         "node_modules/magic-string": {
@@ -1145,9 +1420,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1158,9 +1433,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.6",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-            "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+            "version": "8.5.10",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+            "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -1185,50 +1460,46 @@
                 "node": "^10 || ^12 || >=14"
             }
         },
-        "node_modules/rollup": {
-            "version": "4.57.1",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
-            "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+        "node_modules/rolldown": {
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
+            "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@types/estree": "1.0.8"
+                "@oxc-project/types": "=0.124.0",
+                "@rolldown/pluginutils": "1.0.0-rc.15"
             },
             "bin": {
-                "rollup": "dist/bin/rollup"
+                "rolldown": "bin/cli.mjs"
             },
             "engines": {
-                "node": ">=18.0.0",
-                "npm": ">=8.0.0"
+                "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.57.1",
-                "@rollup/rollup-android-arm64": "4.57.1",
-                "@rollup/rollup-darwin-arm64": "4.57.1",
-                "@rollup/rollup-darwin-x64": "4.57.1",
-                "@rollup/rollup-freebsd-arm64": "4.57.1",
-                "@rollup/rollup-freebsd-x64": "4.57.1",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
-                "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
-                "@rollup/rollup-linux-arm64-gnu": "4.57.1",
-                "@rollup/rollup-linux-arm64-musl": "4.57.1",
-                "@rollup/rollup-linux-loong64-gnu": "4.57.1",
-                "@rollup/rollup-linux-loong64-musl": "4.57.1",
-                "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
-                "@rollup/rollup-linux-ppc64-musl": "4.57.1",
-                "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
-                "@rollup/rollup-linux-riscv64-musl": "4.57.1",
-                "@rollup/rollup-linux-s390x-gnu": "4.57.1",
-                "@rollup/rollup-linux-x64-gnu": "4.57.1",
-                "@rollup/rollup-linux-x64-musl": "4.57.1",
-                "@rollup/rollup-openbsd-x64": "4.57.1",
-                "@rollup/rollup-openharmony-arm64": "4.57.1",
-                "@rollup/rollup-win32-arm64-msvc": "4.57.1",
-                "@rollup/rollup-win32-ia32-msvc": "4.57.1",
-                "@rollup/rollup-win32-x64-gnu": "4.57.1",
-                "@rollup/rollup-win32-x64-msvc": "4.57.1",
-                "fsevents": "~2.3.2"
+                "@rolldown/binding-android-arm64": "1.0.0-rc.15",
+                "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
+                "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
+                "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
+                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
+                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
+                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
+                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
+                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
+                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
+                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
+                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
+                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
+                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
             }
+        },
+        "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
+            "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/source-map-js": {
             "version": "1.2.1",
@@ -1256,18 +1527,25 @@
                 "url": "https://github.com/sponsors/SuperchupuDev"
             }
         },
+        "node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD",
+            "optional": true
+        },
         "node_modules/vite": {
-            "version": "7.3.1",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-            "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+            "version": "8.0.8",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
+            "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "esbuild": "^0.27.0",
-                "fdir": "^6.5.0",
-                "picomatch": "^4.0.3",
-                "postcss": "^8.5.6",
-                "rollup": "^4.43.0",
+                "lightningcss": "^1.32.0",
+                "picomatch": "^4.0.4",
+                "postcss": "^8.5.8",
+                "rolldown": "1.0.0-rc.15",
                 "tinyglobby": "^0.2.15"
             },
             "bin": {
@@ -1284,9 +1562,10 @@
             },
             "peerDependencies": {
                 "@types/node": "^20.19.0 || >=22.12.0",
+                "@vitejs/devtools": "^0.1.0",
+                "esbuild": "^0.27.0 || ^0.28.0",
                 "jiti": ">=1.21.0",
                 "less": "^4.0.0",
-                "lightningcss": "^1.21.0",
                 "sass": "^1.70.0",
                 "sass-embedded": "^1.70.0",
                 "stylus": ">=0.54.8",
@@ -1299,13 +1578,16 @@
                 "@types/node": {
                     "optional": true
                 },
+                "@vitejs/devtools": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
                 "jiti": {
                     "optional": true
                 },
                 "less": {
-                    "optional": true
-                },
-                "lightningcss": {
                     "optional": true
                 },
                 "sass": {

--- a/package.json
+++ b/package.json
@@ -1,15 +1,16 @@
 {
+    "type": "module",
     "private": true,
     "scripts": {
         "dev": "rm -rf resources/dist/build && vite",
         "build": "vite build"
     },
     "dependencies": {
-        "vue": "^2.6.11"
+        "vue": "^3.4.27"
     },
     "devDependencies": {
-        "@vitejs/plugin-vue2": "^2.2.0",
-        "laravel-vite-plugin": "^0.7.2",
-        "vite": "^4.5.2"
+        "@statamic/cms": "file:./vendor/statamic/cms/resources/dist-package",
+        "laravel-vite-plugin": "^2.0.0",
+        "vite": "^7.0.4"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+    "name": "collaboration",
     "type": "module",
     "private": true,
     "scripts": {
@@ -10,7 +11,7 @@
     },
     "devDependencies": {
         "@statamic/cms": "file:./vendor/statamic/cms/resources/dist-package",
-        "laravel-vite-plugin": "^2.0.0",
-        "vite": "^7.0.4"
+        "laravel-vite-plugin": "^3.0.0",
+        "vite": "^8.0.0"
     }
 }

--- a/resources/js/BlockingNotification.vue
+++ b/resources/js/BlockingNotification.vue
@@ -1,17 +1,6 @@
-<template>
-
-    <confirmation-modal
-        :open="true"
-        :title="__('Refresh Required')"
-        :body-text="message"
-        :button-text="__('Refresh')"
-        :cancellable="false"
-        @confirm="emit('confirm')"
-    />
-
-</template>
-
 <script setup>
+import { ConfirmationModal } from '@statamic/cms/ui';
+
 defineProps({
     message: {
         type: String,
@@ -19,5 +8,16 @@ defineProps({
     },
 });
 
-const emit = defineEmits(['confirm']);
+defineEmits(['confirm']);
 </script>
+
+<template>
+  <ConfirmationModal
+      open
+      :title="__('Refresh Required')"
+      :body-text="message"
+      :button-text="__('Refresh')"
+      :cancellable="false"
+      @confirm="$emit('confirm')"
+  />
+</template>

--- a/resources/js/BlockingNotification.vue
+++ b/resources/js/BlockingNotification.vue
@@ -1,25 +1,23 @@
 <template>
 
-    <modal name="confirmation-modal" :pivotY="0.1" :overflow="false">
-        <div class="confirmation-modal flex flex-col h-full">
-            <div class="text-lg font-medium p-2 pb-0">
-                Refresh Required
-            </div>
-            <div class="flex-1 px-2 py-3 text-grey">
-                {{ message }}
-            </div>
-            <div class="p-2 bg-grey-20 border-t flex items-center justify-end text-sm">
-                <button class="btn btn-primary ml-2" @click="$emit('confirm')">Refresh</button>
-            </div>
-        </div>
-    </modal>
+    <confirmation-modal
+        :open="true"
+        :title="__('Refresh Required')"
+        :body-text="message"
+        :button-text="__('Refresh')"
+        :cancellable="false"
+        @confirm="emit('confirm')"
+    />
 
 </template>
 
-<script>
-export default {
+<script setup>
+defineProps({
+    message: {
+        type: String,
+        required: true,
+    },
+});
 
-    props: ['message'],
-
-}
+const emit = defineEmits(['confirm']);
 </script>

--- a/resources/js/StatusBar.vue
+++ b/resources/js/StatusBar.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { computed } from 'vue';
 import { Icon, Dropdown, DropdownMenu, DropdownItem, Avatar } from '@statamic/cms/ui';
+import { useCollaborationStore } from './store';
 
 defineEmits(['unlock']);
 
@@ -11,14 +12,7 @@ const props = defineProps({
     },
 });
 
-const useStore = Statamic.$pinia.defineStore(`collaboration/${props.channelName}`, {
-    state: () => ({
-        users: [],
-    }),
-});
-
-const store = useStore();
-
+const store = useCollaborationStore(props.channelName);
 const users = computed(() => store.users);
 const connecting = computed(() => store.users.length === 0);
 </script>

--- a/resources/js/StatusBar.vue
+++ b/resources/js/StatusBar.vue
@@ -1,49 +1,56 @@
 <template>
 
     <div class="collaboration-status-bar" :class="{ '-mt-2 mb-2': connecting || users.length > 1 }">
-        <loading-graphic v-if="connecting" :inline="true" :size="16" text="Attempting websocket connection..." />
+        <div v-if="connecting" class="flex items-center text-sm text-gray-600">
+            <ui-icon name="loading" class="mr-1" />
+            {{ __('Attempting websocket connection...') }}
+        </div>
         <div v-if="users.length > 1" class="flex items-center">
             <div
                 v-for="user in users"
                 :key="user.id"
             >
-                <dropdown-list>
-                    <template v-slot:trigger>
-                        <avatar
+                <ui-dropdown>
+                    <template #trigger>
+                        <ui-avatar
                             :user="user"
                             class="rounded-full w-6 h-6 mr-1 cursor-pointer text-xs"
                         />
                     </template>
-                    <dropdown-item text="Unlock" @click="$emit('unlock', user)" />
-                </dropdown-list>
+                    <ui-dropdown-menu>
+                        <ui-dropdown-item :text="__('Unlock')" @click="unlock(user)" />
+                    </ui-dropdown-menu>
+                </ui-dropdown>
             </div>
         </div>
     </div>
 
 </template>
 
-<script>
-export default {
+<script setup>
+import { computed } from 'vue';
 
-    props: {
-        container: {
-            required: true,
-        },
-        channelName: {
-            type: String,
-            required: true,
-        }
+const props = defineProps({
+    channelName: {
+        type: String,
+        required: true,
     },
+});
 
-    computed: {
-        users() {
-            return this.$store.state.collaboration[this.channelName].users;
-        },
-        connecting() {
-            return this.users.length === 0;
-        }
-    }
+const useStore = Statamic.$pinia.defineStore(`collaboration/${props.channelName}`, {
+    state: () => ({
+        users: [],
+        focus: {},
+    }),
+});
 
+const store = useStore();
+
+const users = computed(() => store.users);
+const connecting = computed(() => store.users.length === 0);
+
+function unlock(user) {
+    Statamic.$events.$emit(`collaboration.${props.channelName}.unlock`, user);
 }
 </script>
 

--- a/resources/js/StatusBar.vue
+++ b/resources/js/StatusBar.vue
@@ -40,7 +40,6 @@ const props = defineProps({
 const useStore = Statamic.$pinia.defineStore(`collaboration/${props.channelName}`, {
     state: () => ({
         users: [],
-        focus: {},
     }),
 });
 

--- a/resources/js/StatusBar.vue
+++ b/resources/js/StatusBar.vue
@@ -1,34 +1,8 @@
-<template>
-
-    <div class="collaboration-status-bar" :class="{ '-mt-2 mb-2': connecting || users.length > 1 }">
-        <div v-if="connecting" class="flex items-center text-sm text-gray-600">
-            <ui-icon name="loading" class="mr-1" />
-            {{ __('Attempting websocket connection...') }}
-        </div>
-        <div v-if="users.length > 1" class="flex items-center">
-            <div
-                v-for="user in users"
-                :key="user.id"
-            >
-                <ui-dropdown>
-                    <template #trigger>
-                        <ui-avatar
-                            :user="user"
-                            class="rounded-full w-6 h-6 mr-1 cursor-pointer text-xs"
-                        />
-                    </template>
-                    <ui-dropdown-menu>
-                        <ui-dropdown-item :text="__('Unlock')" @click="unlock(user)" />
-                    </ui-dropdown-menu>
-                </ui-dropdown>
-            </div>
-        </div>
-    </div>
-
-</template>
-
 <script setup>
 import { computed } from 'vue';
+import { Icon, Dropdown, DropdownMenu, DropdownItem, Avatar } from '@statamic/cms/ui';
+
+defineEmits(['unlock']);
 
 const props = defineProps({
     channelName: {
@@ -47,12 +21,31 @@ const store = useStore();
 
 const users = computed(() => store.users);
 const connecting = computed(() => store.users.length === 0);
-
-function unlock(user) {
-    Statamic.$events.$emit(`collaboration.${props.channelName}.unlock`, user);
-}
 </script>
 
-<style>
-    .collaboration-status-bar .dropdown-menu { left: 0; }
-</style>
+<template>
+    <div class="collaboration-status-bar" :class="{ '-mt-2 mb-2': connecting || users.length > 1 }">
+        <div v-if="connecting" class="flex items-center text-sm text-gray-600">
+            <Icon name="loading" class="mr-1" />
+            {{ __('Attempting websocket connection...') }}
+        </div>
+        <div v-if="users.length > 1" class="flex items-center">
+            <div
+                v-for="user in users"
+                :key="user.id"
+            >
+                <Dropdown>
+                    <template #trigger>
+                        <Avatar
+                            :user="user"
+                            class="rounded-full w-6 h-6 mr-1 cursor-pointer text-xs"
+                        />
+                    </template>
+                    <DropdownMenu>
+                        <DropdownItem :text="__('Unlock')" @click="$emit('unlock', user)" />
+                    </DropdownMenu>
+                </Dropdown>
+            </div>
+        </div>
+    </div>
+</template>

--- a/resources/js/Workspace.js
+++ b/resources/js/Workspace.js
@@ -2,6 +2,7 @@ import { watch } from 'vue';
 import { debounce } from '@statamic/cms';
 import buddyIn from '../audio/buddy-in.mp3'
 import buddyOut from '../audio/buddy-out.mp3'
+import { useCollaborationStore } from './store';
 
 export default class Workspace {
 
@@ -149,26 +150,7 @@ export default class Workspace {
     }
 
     initializeStore() {
-        const channelName = this.channelName;
-
-        const useStore = Statamic.$pinia.defineStore(`collaboration/${channelName}`, {
-            state: () => ({
-                users: [],
-            }),
-            actions: {
-                setUsers(users) {
-                    this.users = users;
-                },
-                addUser(user) {
-                    this.users.push(user);
-                },
-                removeUser(removedUser) {
-                    this.users = this.users.filter(user => user.id !== removedUser.id);
-                },
-            },
-        });
-
-        this.store = useStore();
+        this.store = useCollaborationStore(this.channelName);
     }
 
     initializeStatusBar() {

--- a/resources/js/Workspace.js
+++ b/resources/js/Workspace.js
@@ -98,9 +98,9 @@ export default class Workspace {
             if (this.initialStateUpdated) return;
             this.debug('✅ Applying broadcasted state change', payload);
             this.container.setValues(payload.values);
-            Object.entries(payload.meta).forEach(([handle, value]) => {
-                this.applyBroadcastedMetaChange({ handle, value });
-            });
+            const restoredMeta = this.restoreEntireMetaPayload(payload.meta || {});
+            this.container.setMeta(restoredMeta);
+            this.lastMetaValues = clone(restoredMeta);
             Object.entries(payload.focus).forEach(([, { user, handle }]) => this.focus(user, handle));
             this.initialStateUpdated = true;
         });
@@ -317,6 +317,13 @@ export default class Workspace {
         });
 
         return { ...payload, value: allowedValues };
+    }
+
+    restoreEntireMetaPayload(payload) {
+        return Object.entries(payload).reduce((restored, [handle, value]) => {
+            restored[handle] = { ...(this.lastMetaValues[handle] || {}), ...value };
+            return restored;
+        }, {});
     }
 
     applyBroadcastedValueChange(payload) {

--- a/resources/js/Workspace.js
+++ b/resources/js/Workspace.js
@@ -24,7 +24,6 @@ export default class Workspace {
         this.initialStateUpdated = false;
 
         this.debouncedBroadcastValueChangeFuncsByHandle = {};
-        this.unlockHandler = null;
         this.focusWatcher = null;
     }
 
@@ -48,10 +47,6 @@ export default class Workspace {
         if (this.focusWatcher) {
             this.focusWatcher();
             this.focusWatcher = null;
-        }
-        if (this.unlockHandler) {
-            Statamic.$events.$off(`collaboration.${this.channelName}.unlock`, this.unlockHandler);
-            this.unlockHandler = null;
         }
         this.echo.leave(this.channelName);
     }
@@ -174,16 +169,15 @@ export default class Workspace {
     }
 
     initializeStatusBar() {
-        this.container.pushComponent('CollaborationStatusBar', {
+        const component = this.container.pushComponent('CollaborationStatusBar', {
             props: {
                 channelName: this.channelName,
             }
         });
 
-        this.unlockHandler = (targetUser) => {
+        component.on('unlock', (targetUser) => {
             this.whisper('force-unlock', { targetUser, originUser: this.user });
-        };
-        Statamic.$events.$on(`collaboration.${this.channelName}.unlock`, this.unlockHandler);
+        });
     }
 
     initializeFocusBlur() {

--- a/resources/js/Workspace.js
+++ b/resources/js/Workspace.js
@@ -10,6 +10,7 @@ export default class Workspace {
         this.echo = null;
         this.started = false;
         this.valuesWatcher = null;
+        this.metaWatcher = null;
         this.store = null;
         this.lastValues = {};
         this.lastMetaValues = {};
@@ -17,6 +18,7 @@ export default class Workspace {
         this.initialStateUpdated = false;
 
         this.debouncedBroadcastValueChangeFuncsByHandle = {};
+        this.debouncedBroadcastMetaChangeFuncsByHandle = {};
         this.focusWatcher = null;
     }
 
@@ -37,6 +39,10 @@ export default class Workspace {
             this.valuesWatcher();
             this.valuesWatcher = null;
         }
+        if (this.metaWatcher) {
+            this.metaWatcher();
+            this.metaWatcher = null;
+        }
         if (this.focusWatcher) {
             this.focusWatcher();
             this.focusWatcher = null;
@@ -51,6 +57,7 @@ export default class Workspace {
 
         this.channel.here(users => {
             this.initializeValueWatcher();
+            this.initializeMetaWatcher();
             this.store.setUsers(users);
         });
 
@@ -59,7 +66,7 @@ export default class Workspace {
             Statamic.$toast.success(`${user.name} has joined.`);
             this.whisper(`initialize-state-for-${user.id}`, {
                 values: this.container.values.value,
-                meta: {},
+                meta: this.container.meta.value,
                 focus: this.container.fieldFocus.value,
             });
 
@@ -90,6 +97,9 @@ export default class Workspace {
             if (this.initialStateUpdated) return;
             this.debug('✅ Applying broadcasted state change', payload);
             this.container.setValues(payload.values);
+            Object.entries(payload.meta).forEach(([handle, value]) => {
+                this.applyBroadcastedMetaChange({ handle, value });
+            });
             Object.entries(payload.focus).forEach(([, { user, handle }]) => this.focus(user, handle));
             this.initialStateUpdated = true;
         });
@@ -243,6 +253,28 @@ export default class Workspace {
         );
     }
 
+    initializeMetaWatcher() {
+        if (this.metaWatcher || !this.container.meta) return;
+
+        this.metaWatcher = watch(
+            this.container.meta,
+            (newMeta) => {
+                Object.keys(newMeta).forEach(handle => {
+                    const newValue = newMeta[handle];
+                    if (this.metaHasChanged(handle, newValue)) {
+                        this.rememberMetaChange(handle, newValue);
+                        this.debouncedBroadcastMetaChangeFuncByHandle(handle)({
+                            handle,
+                            value: newValue,
+                            user: this.user.id,
+                        });
+                    }
+                });
+            },
+            { deep: true }
+        );
+    }
+
     rememberValueChange(handle, value) {
         this.lastValues[handle] = clone(value);
     }
@@ -261,8 +293,23 @@ export default class Workspace {
         return this.debouncedBroadcastValueChangeFuncsByHandle[handle];
     }
 
+    debouncedBroadcastMetaChangeFuncByHandle(handle) {
+        const func = this.debouncedBroadcastMetaChangeFuncsByHandle[handle];
+        if (func) return func;
+
+        this.debouncedBroadcastMetaChangeFuncsByHandle[handle] = debounce((payload) => {
+            this.broadcastMetaChange(payload);
+        }, 500);
+        return this.debouncedBroadcastMetaChangeFuncsByHandle[handle];
+    }
+
     valueHasChanged(handle, newValue) {
         const lastValue = this.lastValues[handle] || null;
+        return JSON.stringify(lastValue) !== JSON.stringify(newValue);
+    }
+
+    metaHasChanged(handle, newValue) {
+        const lastValue = this.lastMetaValues[handle] || null;
         return JSON.stringify(lastValue) !== JSON.stringify(newValue);
     }
 
@@ -270,6 +317,24 @@ export default class Workspace {
         if (this.user.id == payload.user) {
             this.whisper('updated', payload);
         }
+    }
+
+    broadcastMetaChange(payload) {
+        if (this.user.id == payload.user) {
+            this.whisper('meta-updated', this.cleanMetaPayload(payload));
+        }
+    }
+
+    cleanMetaPayload(payload) {
+        const allowed = payload?.value?.__collaboration;
+        if (!allowed) return payload;
+
+        const allowedValues = {};
+        allowed.forEach(key => {
+            allowedValues[key] = payload.value[key];
+        });
+
+        return { ...payload, value: allowedValues };
     }
 
     applyBroadcastedValueChange(payload) {
@@ -282,6 +347,7 @@ export default class Workspace {
         this.debug('✅ Applying broadcasted meta change', payload);
         let value = { ...this.lastMetaValues[payload.handle], ...payload.value };
         this.rememberMetaChange(payload.handle, value);
+        this.container.setFieldMeta(payload.handle, value);
     }
 
     debug(message, args) {
@@ -359,6 +425,6 @@ export default class Workspace {
 
     initializeValuesAndMeta() {
         this.lastValues = clone(this.container.values.value);
-        this.lastMetaValues = {};
+        this.lastMetaValues = clone(this.container.meta?.value || {});
     }
 }

--- a/resources/js/Workspace.js
+++ b/resources/js/Workspace.js
@@ -67,7 +67,7 @@ export default class Workspace {
             Statamic.$toast.success(`${user.name} has joined.`);
             this.whisper(`initialize-state-for-${user.id}`, {
                 values: this.container.values.value,
-                meta: this.container.meta.value,
+                meta: this.cleanEntireMetaPayload(this.container.meta.value),
                 focus: this.container.fieldFocus.value,
             });
 

--- a/resources/js/Workspace.js
+++ b/resources/js/Workspace.js
@@ -137,7 +137,7 @@ export default class Workspace {
             Statamic.$components.append('CollaborationBlockingNotification', {
                 props: { message: messageProp }
             }).on('confirm', () => window.location.reload());
-            this.destroy();
+            this.destroy(); // Stop listening to anything else.
         });
 
         this.listenForWhisper('revision-restored', ({ user }) => {
@@ -145,7 +145,7 @@ export default class Workspace {
             Statamic.$components.append('CollaborationBlockingNotification', {
                 props: { message: `Entry has been restored to another revision by ${user.name}` }
             }).on('confirm', () => window.location.reload());
-            this.destroy();
+            this.destroy(); // Stop listening to anything else.
         });
     }
 
@@ -199,6 +199,8 @@ export default class Workspace {
 
             this.whisper('revision-restored', { user: this.user });
 
+            // Echo doesn't give us a promise, so wait half a second before resolving.
+            // That should be enough time for the whisper to be sent before the the page refreshes.
             setTimeout(resolve, 500);
         });
     }
@@ -258,17 +260,21 @@ export default class Workspace {
     }
 
     rememberValueChange(handle, value) {
+        this.debug('Remembering value change', { handle, value });
         this.lastValues[handle] = clone(value);
     }
 
     rememberMetaChange(handle, value) {
+        this.debug('Remembering meta change', { handle, value });
         this.lastMetaValues[handle] = clone(value);
     }
 
     debouncedBroadcastValueChangeFuncByHandle(handle) {
+        // use existing debounced function if one already exists
         const func = this.debouncedBroadcastValueChangeFuncsByHandle[handle];
         if (func) return func;
 
+        // if the handle has no debounced broadcast function yet, create one and return it
         this.debouncedBroadcastValueChangeFuncsByHandle[handle] = debounce((payload) => {
             this.broadcastValueChange(payload);
         }, 500);
@@ -276,6 +282,7 @@ export default class Workspace {
     }
 
     debouncedBroadcastMetaChangeFuncByHandle(handle) {
+        // use existing debounced function if one already exists
         const func = this.debouncedBroadcastMetaChangeFuncsByHandle[handle];
         if (func) return func;
 
@@ -296,17 +303,25 @@ export default class Workspace {
     }
 
     broadcastValueChange(payload) {
+        // Only my own change events should be broadcasted. Otherwise when other users receive
+        // the broadcast, it will be re-broadcasted, and so on, to infinity and beyond.
         if (this.user.id == payload.user) {
             this.whisper('updated', payload);
         }
     }
 
     broadcastMetaChange(payload) {
+        // Only my own change events should be broadcasted. Otherwise when other users receive
+        // the broadcast, it will be re-broadcasted, and so on, to infinity and beyond.
         if (this.user.id == payload.user) {
             this.whisper('meta-updated', this.cleanMetaPayload(payload));
         }
     }
 
+    // Allow fieldtypes to provide an array of keys that will be broadcasted.
+    // For example, in Bard, only the "existing" value in its meta object
+    // ever gets updated. We'll just broadcast that, rather than the
+    // whole thing, which would be wasted bytes in the message.
     cleanMetaPayload(payload) {
         const allowed = payload?.value?.__collaboration;
         if (!allowed) return payload;
@@ -317,6 +332,16 @@ export default class Workspace {
         });
 
         return { ...payload, value: allowedValues };
+    }
+
+    // Similar to cleanMetaPayload, except for when dealing with the
+    // entire list of fields' meta values. Used when a user joins
+    // and needs to receive everything in one fell swoop.
+    cleanEntireMetaPayload(meta = {}) {
+        return Object.entries(meta).reduce((cleaned, [handle, value]) => {
+            cleaned[handle] = this.cleanMetaPayload({ handle, value }).value;
+            return cleaned;
+        }, {});
     }
 
     restoreEntireMetaPayload(payload) {
@@ -340,7 +365,7 @@ export default class Workspace {
     }
 
     debug(message, args) {
-        console.log('[Collaboration]', message, { ...args });
+        console.log('[Collaboration]', message, {...args});
     }
 
     isAlone() {
@@ -379,7 +404,7 @@ export default class Workspace {
 
         let events = {};
         this.channel.listenForWhisper(`chunked-${event}`, data => {
-            if (!events.hasOwnProperty(data.id)) {
+            if (! events.hasOwnProperty(data.id)) {
                 events[data.id] = { chunks: [], receivedFinal: false };
             }
 

--- a/resources/js/Workspace.js
+++ b/resources/js/Workspace.js
@@ -286,6 +286,7 @@ export default class Workspace {
         const func = this.debouncedBroadcastMetaChangeFuncsByHandle[handle];
         if (func) return func;
 
+        // if the handle has no debounced broadcast function yet, create one and return it
         this.debouncedBroadcastMetaChangeFuncsByHandle[handle] = debounce((payload) => {
             this.broadcastMetaChange(payload);
         }, 500);
@@ -323,22 +324,19 @@ export default class Workspace {
     // ever gets updated. We'll just broadcast that, rather than the
     // whole thing, which would be wasted bytes in the message.
     cleanMetaPayload(payload) {
-        const allowed = payload?.value?.__collaboration;
-        if (!allowed) return payload;
-
-        const allowedValues = {};
-        allowed.forEach(key => {
-            allowedValues[key] = payload.value[key];
-        });
-
-        return { ...payload, value: allowedValues };
+        const allowed = data_get(payload, 'value.__collaboration');
+        if (! allowed) return payload;
+        let allowedValues = {};
+        allowed.forEach(key => allowedValues[key] = payload.value[key]);
+        payload.value = allowedValues;
+        return payload;
     }
 
     // Similar to cleanMetaPayload, except for when dealing with the
     // entire list of fields' meta values. Used when a user joins
     // and needs to receive everything in one fell swoop.
-    cleanEntireMetaPayload(meta = {}) {
-        return Object.entries(meta).reduce((cleaned, [handle, value]) => {
+    cleanEntireMetaPayload(values) {
+        return Object.entries(values).reduce((cleaned, [handle, value]) => {
             cleaned[handle] = this.cleanMetaPayload({ handle, value }).value;
             return cleaned;
         }, {});

--- a/resources/js/Workspace.js
+++ b/resources/js/Workspace.js
@@ -1,5 +1,14 @@
+import { watch } from 'vue';
 import buddyIn from '../audio/buddy-in.mp3'
 import buddyOut from '../audio/buddy-out.mp3'
+
+function debounce(fn, delay) {
+    let timer;
+    return function (...args) {
+        clearTimeout(timer);
+        timer = setTimeout(() => fn.apply(this, args), delay);
+    };
+}
 
 export default class Workspace {
 
@@ -7,14 +16,17 @@ export default class Workspace {
         this.container = container;
         this.echo = null;
         this.started = false;
-        this.storeSubscriber = null;
+        this.valuesWatcher = null;
+        this.store = null;
         this.lastValues = {};
         this.lastMetaValues = {};
         this.user = Statamic.user;
         this.initialStateUpdated = false;
 
         this.debouncedBroadcastValueChangeFuncsByHandle = {};
-        this.debouncedBroadcastMetaChangeFuncsByHandle = {};
+        this.unlockHandler = null;
+        this._fieldFocusedHandler = null;
+        this._fieldBlurredHandler = null;
     }
 
     start() {
@@ -22,15 +34,28 @@ export default class Workspace {
 
         this.initializeEcho();
         this.initializeStore();
-        this.initializeFocus();
         this.initializeValuesAndMeta();
         this.initializeHooks();
         this.initializeStatusBar();
+        this.initializeFocusBlur();
         this.started = true;
     }
 
     destroy() {
-        this.storeSubscriber.apply();
+        if (this.valuesWatcher) {
+            this.valuesWatcher();
+            this.valuesWatcher = null;
+        }
+        if (this.unlockHandler) {
+            Statamic.$events.$off(`collaboration.${this.channelName}.unlock`, this.unlockHandler);
+            this.unlockHandler = null;
+        }
+        if (this._fieldFocusedHandler) {
+            Statamic.$events.$off('field:focused', this._fieldFocusedHandler);
+            Statamic.$events.$off('field:blurred', this._fieldBlurredHandler);
+            this._fieldFocusedHandler = null;
+            this._fieldBlurredHandler = null;
+        }
         this.echo.leave(this.channelName);
     }
 
@@ -40,17 +65,17 @@ export default class Workspace {
         this.channel = this.echo.join(this.channelName);
 
         this.channel.here(users => {
-            this.subscribeToVuexMutations();
-            Statamic.$store.commit(`collaboration/${this.channelName}/setUsers`, users);
+            this.initializeValueWatcher();
+            this.store.setUsers(users);
         });
 
         this.channel.joining(user => {
-            Statamic.$store.commit(`collaboration/${this.channelName}/addUser`, user);
+            this.store.addUser(user);
             Statamic.$toast.success(`${user.name} has joined.`);
             this.whisper(`initialize-state-for-${user.id}`, {
-                values: Statamic.$store.state.publish[this.container.name].values,
-                meta: this.cleanEntireMetaPayload(Statamic.$store.state.publish[this.container.name].meta),
-                focus: Statamic.$store.state.collaboration[this.channelName].focus,
+                values: this.container.container.values,
+                meta: {},
+                focus: this.store.focus,
             });
 
             if (Statamic.$config.get('collaboration.sound_effects')) {
@@ -59,7 +84,7 @@ export default class Workspace {
         });
 
         this.channel.leaving(user => {
-            Statamic.$store.commit(`collaboration/${this.channelName}/removeUser`, user);
+            this.store.removeUser(user);
             Statamic.$toast.success(`${user.name} has left.`);
             this.blurAndUnlock(user);
 
@@ -79,9 +104,8 @@ export default class Workspace {
         this.listenForWhisper(`initialize-state-for-${this.user.id}`, payload => {
             if (this.initialStateUpdated) return;
             this.debug('✅ Applying broadcasted state change', payload);
-            Statamic.$store.dispatch(`publish/${this.container.name}/setValues`, payload.values);
-            Statamic.$store.dispatch(`publish/${this.container.name}/setMeta`, this.restoreEntireMetaPayload(payload.meta));
-            _.each(payload.focus, ({ user, handle }) => this.focusAndLock(user, handle));
+            this.container.container.setValues(payload.values);
+            Object.entries(payload.focus).forEach(([, { user, handle }]) => this.focusAndLock(user, handle));
             this.initialStateUpdated = true;
         });
 
@@ -118,7 +142,7 @@ export default class Workspace {
             Statamic.$components.append('CollaborationBlockingNotification', {
                 props: { message: messageProp }
             }).on('confirm', () => window.location.reload());
-            this.destroy(); // Stop listening to anything else.
+            this.destroy();
         });
 
         this.listenForWhisper('revision-restored', ({ user }) => {
@@ -126,48 +150,68 @@ export default class Workspace {
             Statamic.$components.append('CollaborationBlockingNotification', {
                 props: { message: `Entry has been restored to another revision by ${user.name}` }
             }).on('confirm', () => window.location.reload());
-            this.destroy(); // Stop listening to anything else.
+            this.destroy();
         });
     }
 
     initializeStore() {
-        Statamic.$store.registerModule(['collaboration', this.channelName], {
-            namespaced: true,
-            state: {
+        const channelName = this.channelName;
+
+        const useStore = Statamic.$pinia.defineStore(`collaboration/${channelName}`, {
+            state: () => ({
                 users: [],
                 focus: {},
+            }),
+            actions: {
+                setUsers(users) {
+                    this.users = users;
+                },
+                addUser(user) {
+                    this.users.push(user);
+                },
+                removeUser(removedUser) {
+                    this.users = this.users.filter(user => user.id !== removedUser.id);
+                },
+                setFocus(handle, user) {
+                    this.focus[user.id] = { handle, user };
+                },
+                clearFocus(user) {
+                    delete this.focus[user.id];
+                },
             },
-            mutations: {
-                setUsers(state, users) {
-                    state.users = users;
-                },
-                addUser(state, user) {
-                    state.users.push(user);
-                },
-                removeUser(state, removedUser) {
-                    state.users = state.users.filter(user => user.id !== removedUser.id);
-                },
-                focus(state, { handle, user }) {
-                    Vue.set(state.focus, user.id, { handle, user });
-                },
-                blur(state, user) {
-                    Vue.delete(state.focus, user.id);
-                }
-            }
         });
+
+        this.store = useStore();
     }
 
     initializeStatusBar() {
-        const component = this.container.pushComponent('CollaborationStatusBar', {
+        this.container.container.pushComponent('CollaborationStatusBar', {
             props: {
                 channelName: this.channelName,
-                connecting: this.connecting,
             }
         });
 
-        component.on('unlock', (targetUser) => {
+        this.unlockHandler = (targetUser) => {
             this.whisper('force-unlock', { targetUser, originUser: this.user });
-        });
+        };
+        Statamic.$events.$on(`collaboration.${this.channelName}.unlock`, this.unlockHandler);
+    }
+
+    initializeFocusBlur() {
+        this._fieldFocusedHandler = ({ containerName, handle }) => {
+            if (containerName !== this.container.name) return;
+            this.focusAndLock(this.user, handle);
+            this.whisper('focus', { user: this.user, handle });
+        };
+
+        this._fieldBlurredHandler = ({ containerName, handle }) => {
+            if (containerName !== this.container.name) return;
+            this.blurAndUnlock(this.user, handle);
+            this.whisper('blur', { user: this.user, handle });
+        };
+
+        Statamic.$events.$on('field:focused', this._fieldFocusedHandler);
+        Statamic.$events.$on('field:blurred', this._fieldBlurredHandler);
     }
 
     initializeHooks() {
@@ -190,120 +234,68 @@ export default class Workspace {
 
             this.whisper('revision-restored', { user: this.user });
 
-            // Echo doesn't give us a promise, so wait half a second before resolving.
-            // That should be enough time for the whisper to be sent before the the page refreshes.
             setTimeout(resolve, 500);
         });
     }
 
-    initializeFocus() {
-        this.container.$on('focus', handle => {
-            const user = this.user;
-            this.focus(user, handle);
-            this.whisper('focus', { user, handle });
-        });
-        this.container.$on('blur', handle => {
-            const user = this.user;
-            this.blur(user, handle);
-            this.whisper('blur', { user, handle });
-        });
-    }
-
     focus(user, handle) {
-        Statamic.$store.commit(`collaboration/${this.channelName}/focus`, { user, handle });
+        this.store.setFocus(handle, user);
     }
 
     focusAndLock(user, handle) {
         this.focus(user, handle);
-        Statamic.$store.commit(`publish/${this.container.name}/lockField`, { user, handle });
+        Statamic.$events.$emit('field:lock', { containerName: this.container.name, handle, user });
     }
 
     blur(user) {
-        Statamic.$store.commit(`collaboration/${this.channelName}/blur`, user);
+        this.store.clearFocus(user);
     }
 
     blurAndUnlock(user, handle = null) {
-        handle = handle || data_get(Statamic.$store.state.collaboration[this.channelName], `focus.${user.id}.handle`);
+        handle = handle || data_get(this.store.focus, `${user.id}.handle`);
         if (!handle) return;
         this.blur(user);
-        Statamic.$store.commit(`publish/${this.container.name}/unlockField`, handle);
+        Statamic.$events.$emit('field:unlock', { containerName: this.container.name, handle });
     }
 
-    subscribeToVuexMutations() {
-        this.storeSubscriber = Statamic.$store.subscribe((mutation, state) => {
-            switch (mutation.type) {
-                case `publish/${this.container.name}/setFieldValue`:
-                    this.vuexFieldValueHasBeenSet(mutation.payload);
-                    break;
-                case `publish/${this.container.name}/setFieldMeta`:
-                    this.vuexFieldMetaHasBeenSet(mutation.payload);
-                    break;
-            }
-        });
-    }
+    initializeValueWatcher() {
+        if (this.valuesWatcher) return;
 
-    // A field's value has been set in the vuex store.
-    // It could have been triggered by the current user editing something,
-    // or by the workspace applying a change dispatched by another user editing something.
-    vuexFieldValueHasBeenSet(payload) {
-        this.debug('Vuex field value has been set', payload);
-        if (!this.valueHasChanged(payload.handle, payload.value)) {
-            // No change? Don't bother doing anything.
-            this.debug(`Value for ${payload.handle} has not changed.`, { value: payload.value, lastValue: this.lastValues[payload.handle] });
-            return;
-        }
-
-        this.rememberValueChange(payload.handle, payload.value);
-        this.debouncedBroadcastValueChangeFuncByHandle(payload.handle)(payload);
-    }
-
-    // A field's meta value has been set in the vuex store.
-    // It could have been triggered by the current user editing something,
-    // or by the workspace applying a change dispatched by another user editing something.
-    vuexFieldMetaHasBeenSet(payload) {
-        this.debug('Vuex field meta has been set', payload);
-        if (!this.metaHasChanged(payload.handle, payload.value)) {
-            // No change? Don't bother doing anything.
-            this.debug(`Meta for ${payload.handle} has not changed.`, { value: payload.value, lastValue: this.lastMetaValues[payload.handle] });
-            return;
-        }
-
-        this.rememberMetaChange(payload.handle, payload.value);
-        this.debouncedBroadcastMetaChangeFuncByHandle(payload.handle)(payload);
+        this.valuesWatcher = watch(
+            () => this.container.container.values,
+            (newValues) => {
+                Object.keys(newValues).forEach(handle => {
+                    const newValue = newValues[handle];
+                    if (this.valueHasChanged(handle, newValue)) {
+                        this.rememberValueChange(handle, newValue);
+                        this.debouncedBroadcastValueChangeFuncByHandle(handle)({
+                            handle,
+                            value: newValue,
+                            user: this.user.id,
+                        });
+                    }
+                });
+            },
+            { deep: true }
+        );
     }
 
     rememberValueChange(handle, value) {
-        this.debug('Remembering value change', { handle, value });
         this.lastValues[handle] = clone(value);
     }
 
     rememberMetaChange(handle, value) {
-        this.debug('Remembering meta change', { handle, value });
         this.lastMetaValues[handle] = clone(value);
     }
 
     debouncedBroadcastValueChangeFuncByHandle(handle) {
-        // use existing debounced function if one already exists
         const func = this.debouncedBroadcastValueChangeFuncsByHandle[handle];
         if (func) return func;
 
-        // if the handle has no debounced broadcast function yet, create one and return it
-        this.debouncedBroadcastValueChangeFuncsByHandle[handle] = _.debounce((payload) => {
+        this.debouncedBroadcastValueChangeFuncsByHandle[handle] = debounce((payload) => {
             this.broadcastValueChange(payload);
         }, 500);
         return this.debouncedBroadcastValueChangeFuncsByHandle[handle];
-    }
-
-    debouncedBroadcastMetaChangeFuncByHandle(handle) {
-        // use existing debounced function if one already exists
-        const func = this.debouncedBroadcastMetaChangeFuncsByHandle[handle];
-        if (func) return func;
-
-        // if the handle has no debounced broadcast function yet, create one and return it
-        this.debouncedBroadcastMetaChangeFuncsByHandle[handle] = _.debounce((payload) => {
-            this.broadcastMetaChange(payload);
-        }, 500);
-        return this.debouncedBroadcastMetaChangeFuncsByHandle[handle];
     }
 
     valueHasChanged(handle, newValue) {
@@ -311,77 +303,30 @@ export default class Workspace {
         return JSON.stringify(lastValue) !== JSON.stringify(newValue);
     }
 
-    metaHasChanged(handle, newValue) {
-        const lastValue = this.lastMetaValues[handle] || null;
-        return JSON.stringify(lastValue) !== JSON.stringify(newValue);
-    }
-
     broadcastValueChange(payload) {
-        // Only my own change events should be broadcasted. Otherwise when other users receive
-        // the broadcast, it will be re-broadcasted, and so on, to infinity and beyond.
         if (this.user.id == payload.user) {
             this.whisper('updated', payload);
         }
     }
 
-    broadcastMetaChange(payload) {
-        // Only my own change events should be broadcasted. Otherwise when other users receive
-        // the broadcast, it will be re-broadcasted, and so on, to infinity and beyond.
-        if (this.user.id == payload.user) {
-            this.whisper('meta-updated', this.cleanMetaPayload(payload));
-        }
-    }
-
-    // Allow fieldtypes to provide an array of keys that will be broadcasted.
-    // For example, in Bard, only the "existing" value in its meta object
-    // ever gets updated. We'll just broadcast that, rather than the
-    // whole thing, which would be wasted bytes in the message.
-    cleanMetaPayload(payload) {
-        const allowed = data_get(payload, 'value.__collaboration');
-        if (! allowed) return payload;
-        let allowedValues = {};
-        allowed.forEach(key => allowedValues[key] = payload.value[key]);
-        payload.value = allowedValues;
-        return payload;
-    }
-
-    // Similar to cleanMetaPayload, except for when dealing with the
-    // entire list of fields' meta values. Used when a user joins
-    // and needs to receive everything in one fell swoop.
-    cleanEntireMetaPayload(values) {
-        return _.mapObject(values, meta => {
-            const allowed = data_get(meta, '__collaboration');
-            if (!allowed) return meta;
-            let allowedValues = {};
-            allowed.forEach(key => allowedValues[key] = meta[key]);
-            return allowedValues;
-        });
-    }
-
-    restoreEntireMetaPayload(payload) {
-        return _.mapObject(payload, (value, key) => {
-            return {...this.lastMetaValues[key], ...value};
-        });
-    }
-
     applyBroadcastedValueChange(payload) {
         this.debug('✅ Applying broadcasted value change', payload);
-        Statamic.$store.dispatch(`publish/${this.container.name}/setFieldValue`, payload);
+        this.rememberValueChange(payload.handle, payload.value);
+        this.container.container.setFieldValue(payload.handle, payload.value);
     }
 
     applyBroadcastedMetaChange(payload) {
         this.debug('✅ Applying broadcasted meta change', payload);
-        let value = {...this.lastMetaValues[payload.handle], ...payload.value};
-        payload.value = value;
-        Statamic.$store.dispatch(`publish/${this.container.name}/setFieldMeta`, payload);
+        let value = { ...this.lastMetaValues[payload.handle], ...payload.value };
+        this.rememberMetaChange(payload.handle, value);
     }
 
     debug(message, args) {
-        console.log('[Collaboration]', message, {...args});
+        console.log('[Collaboration]', message, { ...args });
     }
 
     isAlone() {
-        return Statamic.$store.state.collaboration[this.channelName].users.length === 1;
+        return this.store.users.length === 1;
     }
 
     whisper(event, payload) {
@@ -416,7 +361,7 @@ export default class Workspace {
 
         let events = {};
         this.channel.listenForWhisper(`chunked-${event}`, data => {
-            if (! events.hasOwnProperty(data.id)) {
+            if (!events.hasOwnProperty(data.id)) {
                 events[data.id] = { chunks: [], receivedFinal: false };
             }
 
@@ -450,7 +395,7 @@ export default class Workspace {
     }
 
     initializeValuesAndMeta() {
-        this.lastValues = clone(Statamic.$store.state.publish[this.container.name].values);
-        this.lastMetaValues = clone(Statamic.$store.state.publish[this.container.name].meta);
+        this.lastValues = clone(this.container.container.values);
+        this.lastMetaValues = {};
     }
 }

--- a/resources/js/Workspace.js
+++ b/resources/js/Workspace.js
@@ -98,6 +98,7 @@ export default class Workspace {
             if (this.initialStateUpdated) return;
             this.debug('✅ Applying broadcasted state change', payload);
             this.container.setValues(payload.values);
+            this.lastValues = clone(payload.values);
             const restoredMeta = this.restoreEntireMetaPayload(payload.meta || {});
             this.container.setMeta(restoredMeta);
             this.lastMetaValues = clone(restoredMeta);

--- a/resources/js/Workspace.js
+++ b/resources/js/Workspace.js
@@ -1,14 +1,7 @@
 import { watch } from 'vue';
+import { debounce } from '@statamic/cms';
 import buddyIn from '../audio/buddy-in.mp3'
 import buddyOut from '../audio/buddy-out.mp3'
-
-function debounce(fn, delay) {
-    let timer;
-    return function (...args) {
-        clearTimeout(timer);
-        timer = setTimeout(() => fn.apply(this, args), delay);
-    };
-}
 
 export default class Workspace {
 

--- a/resources/js/Workspace.js
+++ b/resources/js/Workspace.js
@@ -25,8 +25,7 @@ export default class Workspace {
 
         this.debouncedBroadcastValueChangeFuncsByHandle = {};
         this.unlockHandler = null;
-        this._fieldFocusedHandler = null;
-        this._fieldBlurredHandler = null;
+        this.focusWatcher = null;
     }
 
     start() {
@@ -46,15 +45,13 @@ export default class Workspace {
             this.valuesWatcher();
             this.valuesWatcher = null;
         }
+        if (this.focusWatcher) {
+            this.focusWatcher();
+            this.focusWatcher = null;
+        }
         if (this.unlockHandler) {
             Statamic.$events.$off(`collaboration.${this.channelName}.unlock`, this.unlockHandler);
             this.unlockHandler = null;
-        }
-        if (this._fieldFocusedHandler) {
-            Statamic.$events.$off('field:focused', this._fieldFocusedHandler);
-            Statamic.$events.$off('field:blurred', this._fieldBlurredHandler);
-            this._fieldFocusedHandler = null;
-            this._fieldBlurredHandler = null;
         }
         this.echo.leave(this.channelName);
     }
@@ -73,9 +70,9 @@ export default class Workspace {
             this.store.addUser(user);
             Statamic.$toast.success(`${user.name} has joined.`);
             this.whisper(`initialize-state-for-${user.id}`, {
-                values: this.container.container.values,
+                values: this.container.values.value,
                 meta: {},
-                focus: this.store.focus,
+                focus: this.container.fieldFocus.value,
             });
 
             if (Statamic.$config.get('collaboration.sound_effects')) {
@@ -86,7 +83,7 @@ export default class Workspace {
         this.channel.leaving(user => {
             this.store.removeUser(user);
             Statamic.$toast.success(`${user.name} has left.`);
-            this.blurAndUnlock(user);
+            this.blur(user);
 
             if (Statamic.$config.get('collaboration.sound_effects')) {
                 this.playAudio('buddy-out');
@@ -104,19 +101,19 @@ export default class Workspace {
         this.listenForWhisper(`initialize-state-for-${this.user.id}`, payload => {
             if (this.initialStateUpdated) return;
             this.debug('✅ Applying broadcasted state change', payload);
-            this.container.container.setValues(payload.values);
-            Object.entries(payload.focus).forEach(([, { user, handle }]) => this.focusAndLock(user, handle));
+            this.container.setValues(payload.values);
+            Object.entries(payload.focus).forEach(([, { user, handle }]) => this.focus(user, handle));
             this.initialStateUpdated = true;
         });
 
         this.listenForWhisper('focus', ({ user, handle }) => {
             this.debug(`Heard that user has changed focus`, { user, handle });
-            this.focusAndLock(user, handle);
+            this.focus(user, handle);
         });
 
         this.listenForWhisper('blur', ({ user, handle }) => {
             this.debug(`Heard that user has blurred`, { user, handle });
-            this.blurAndUnlock(user, handle);
+            this.blur(user, handle);
         });
 
         this.listenForWhisper('force-unlock', ({ targetUser, originUser }) => {
@@ -125,8 +122,7 @@ export default class Workspace {
             if (targetUser.id !== this.user.id) return;
 
             document.activeElement.blur();
-            this.blurAndUnlock(this.user);
-            this.whisper('blur', { user: this.user });
+            this.blur(this.user);
             Statamic.$toast.info(`${originUser.name} has unlocked your editor.`, { duration: false });
         });
 
@@ -160,7 +156,6 @@ export default class Workspace {
         const useStore = Statamic.$pinia.defineStore(`collaboration/${channelName}`, {
             state: () => ({
                 users: [],
-                focus: {},
             }),
             actions: {
                 setUsers(users) {
@@ -172,12 +167,6 @@ export default class Workspace {
                 removeUser(removedUser) {
                     this.users = this.users.filter(user => user.id !== removedUser.id);
                 },
-                setFocus(handle, user) {
-                    this.focus[user.id] = { handle, user };
-                },
-                clearFocus(user) {
-                    delete this.focus[user.id];
-                },
             },
         });
 
@@ -185,7 +174,7 @@ export default class Workspace {
     }
 
     initializeStatusBar() {
-        this.container.container.pushComponent('CollaborationStatusBar', {
+        this.container.pushComponent('CollaborationStatusBar', {
             props: {
                 channelName: this.channelName,
             }
@@ -198,20 +187,17 @@ export default class Workspace {
     }
 
     initializeFocusBlur() {
-        this._fieldFocusedHandler = ({ containerName, handle }) => {
-            if (containerName !== this.container.name) return;
-            this.focusAndLock(this.user, handle);
-            this.whisper('focus', { user: this.user, handle });
-        };
-
-        this._fieldBlurredHandler = ({ containerName, handle }) => {
-            if (containerName !== this.container.name) return;
-            this.blurAndUnlock(this.user, handle);
-            this.whisper('blur', { user: this.user, handle });
-        };
-
-        Statamic.$events.$on('field:focused', this._fieldFocusedHandler);
-        Statamic.$events.$on('field:blurred', this._fieldBlurredHandler);
+        this.focusWatcher = watch(
+            () => this.container.fieldFocus.value[this.user.id]?.handle,
+            (newHandle, oldHandle) => {
+                if (oldHandle) {
+                    this.whisper('blur', { user: this.user, handle: oldHandle });
+                }
+                if (newHandle) {
+                    this.whisper('focus', { user: this.user, handle: newHandle });
+                }
+            }
+        );
     }
 
     initializeHooks() {
@@ -239,30 +225,20 @@ export default class Workspace {
     }
 
     focus(user, handle) {
-        this.store.setFocus(handle, user);
+        this.container.focusField(handle, user);
     }
 
-    focusAndLock(user, handle) {
-        this.focus(user, handle);
-        Statamic.$events.$emit('field:lock', { containerName: this.container.name, handle, user });
-    }
-
-    blur(user) {
-        this.store.clearFocus(user);
-    }
-
-    blurAndUnlock(user, handle = null) {
-        handle = handle || data_get(this.store.focus, `${user.id}.handle`);
+    blur(user, handle = null) {
+        handle = handle || this.container.fieldFocus.value[user.id]?.handle;
         if (!handle) return;
-        this.blur(user);
-        Statamic.$events.$emit('field:unlock', { containerName: this.container.name, handle });
+        this.container.blurField(handle, user);
     }
 
     initializeValueWatcher() {
         if (this.valuesWatcher) return;
 
         this.valuesWatcher = watch(
-            () => this.container.container.values,
+            this.container.values,
             (newValues) => {
                 Object.keys(newValues).forEach(handle => {
                     const newValue = newValues[handle];
@@ -312,7 +288,7 @@ export default class Workspace {
     applyBroadcastedValueChange(payload) {
         this.debug('✅ Applying broadcasted value change', payload);
         this.rememberValueChange(payload.handle, payload.value);
-        this.container.container.setFieldValue(payload.handle, payload.value);
+        this.container.setFieldValue(payload.handle, payload.value);
     }
 
     applyBroadcastedMetaChange(payload) {
@@ -395,7 +371,7 @@ export default class Workspace {
     }
 
     initializeValuesAndMeta() {
-        this.lastValues = clone(this.container.container.values);
+        this.lastValues = clone(this.container.values.value);
         this.lastMetaValues = {};
     }
 }

--- a/resources/js/collaboration.js
+++ b/resources/js/collaboration.js
@@ -16,10 +16,13 @@ Statamic.$echo.booted(Echo => {
 Statamic.$events.$on('publish-container-created', container => {
     if (!container.reference) return;
     manager.addWorkspace(container);
-    window.addEventListener('unload', () => manager.destroyWorkspace(container));
 });
 
 Statamic.$events.$on('publish-container-destroyed', container => {
     if (!manager.workspaces[container.name]) return;
     manager.destroyWorkspace(container);
+});
+
+window.addEventListener('unload', () => {
+    Object.keys(manager.workspaces).forEach(name => manager.destroyWorkspace({ name }));
 });

--- a/resources/js/collaboration.js
+++ b/resources/js/collaboration.js
@@ -1,43 +1,23 @@
-import { nextTick } from 'vue';
 import Manager from './Manager';
 import StatusBar from './StatusBar.vue';
 import BlockingNotification from './BlockingNotification.vue';
 
 const manager = new Manager;
 
-const originalBoot = Statamic.$components.boot.bind(Statamic.$components);
-Statamic.$components.boot = function (app) {
-    app.mixin({
-        mounted() {
-            if (!this.publishContainer || !this.initialReference) return;
-
-            nextTick(() => {
-                const container = this.$refs.container;
-                if (!container) return;
-
-                manager.addWorkspace({
-                    name: this.publishContainer,
-                    reference: this.initialReference,
-                    site: this.site,
-                    container,
-                });
-            });
-        },
-
-        beforeUnmount() {
-            if (!this.publishContainer || !this.initialReference) return;
-            if (manager.workspaces[this.publishContainer]) {
-                manager.destroyWorkspace({ name: this.publishContainer });
-            }
-        },
-    });
-
-    return originalBoot(app);
-};
-
 Statamic.booting(() => {
     Statamic.$components.register('CollaborationStatusBar', StatusBar);
     Statamic.$components.register('CollaborationBlockingNotification', BlockingNotification);
+});
+
+Statamic.$events.$on('publish-container-created', (container) => {
+    if (!container.reference) return;
+    manager.addWorkspace(container);
+});
+
+Statamic.$events.$on('publish-container-destroyed', (container) => {
+    if (manager.workspaces[container.name]) {
+        manager.destroyWorkspace(container);
+    }
 });
 
 Statamic.$echo.booted(Echo => {

--- a/resources/js/collaboration.js
+++ b/resources/js/collaboration.js
@@ -12,6 +12,7 @@ Statamic.booting(() => {
 Statamic.$events.$on('publish-container-created', (container) => {
     if (!container.reference) return;
     manager.addWorkspace(container);
+    window.addEventListener('unload', () => manager.destroyWorkspace(container));
 });
 
 Statamic.$events.$on('publish-container-destroyed', (container) => {

--- a/resources/js/collaboration.js
+++ b/resources/js/collaboration.js
@@ -1,29 +1,46 @@
+import { nextTick } from 'vue';
 import Manager from './Manager';
 import StatusBar from './StatusBar.vue';
 import BlockingNotification from './BlockingNotification.vue';
+
 const manager = new Manager;
 
-Statamic.booting(() => {
-    Statamic.component('CollaborationStatusBar', StatusBar);
-    Statamic.component('CollaborationBlockingNotification', BlockingNotification);
+const originalBoot = Statamic.$components.boot.bind(Statamic.$components);
+Statamic.$components.boot = function (app) {
+    app.mixin({
+        mounted() {
+            if (!this.publishContainer || !this.initialReference) return;
 
-    Statamic.$store.registerModule('collaboration', {
-        namespaced: true
+            nextTick(() => {
+                const container = this.$refs.container;
+                if (!container) return;
+
+                manager.addWorkspace({
+                    name: this.publishContainer,
+                    reference: this.initialReference,
+                    site: this.site,
+                    container,
+                });
+            });
+        },
+
+        beforeUnmount() {
+            if (!this.publishContainer || !this.initialReference) return;
+            if (manager.workspaces[this.publishContainer]) {
+                manager.destroyWorkspace({ name: this.publishContainer });
+            }
+        },
     });
+
+    return originalBoot(app);
+};
+
+Statamic.booting(() => {
+    Statamic.$components.register('CollaborationStatusBar', StatusBar);
+    Statamic.$components.register('CollaborationBlockingNotification', BlockingNotification);
 });
 
 Statamic.$echo.booted(Echo => {
     manager.echo = Echo;
     manager.boot();
-});
-
-Statamic.$events.$on('publish-container-created', container => {
-    if (!container.reference) return;
-    manager.addWorkspace(container);
-    window.addEventListener('unload', () => manager.destroyWorkspace(container));
-});
-
-Statamic.$events.$on('publish-container-destroyed', container => {
-    if (!manager.workspaces[container.name]) return;
-    manager.destroyWorkspace(container);
 });

--- a/resources/js/collaboration.js
+++ b/resources/js/collaboration.js
@@ -1,7 +1,6 @@
 import Manager from './Manager';
 import StatusBar from './StatusBar.vue';
 import BlockingNotification from './BlockingNotification.vue';
-
 const manager = new Manager;
 
 Statamic.booting(() => {
@@ -9,16 +8,15 @@ Statamic.booting(() => {
     Statamic.$components.register('CollaborationBlockingNotification', BlockingNotification);
 });
 
-Statamic.$events.$on('publish-container-created', (container) => {
+Statamic.$events.$on('publish-container-created', container => {
     if (!container.reference) return;
     manager.addWorkspace(container);
     window.addEventListener('unload', () => manager.destroyWorkspace(container));
 });
 
-Statamic.$events.$on('publish-container-destroyed', (container) => {
-    if (manager.workspaces[container.name]) {
-        manager.destroyWorkspace(container);
-    }
+Statamic.$events.$on('publish-container-destroyed', container => {
+    if (!manager.workspaces[container.name]) return;
+    manager.destroyWorkspace(container);
 });
 
 Statamic.$echo.booted(Echo => {

--- a/resources/js/collaboration.js
+++ b/resources/js/collaboration.js
@@ -8,6 +8,11 @@ Statamic.booting(() => {
     Statamic.$components.register('CollaborationBlockingNotification', BlockingNotification);
 });
 
+Statamic.$echo.booted(Echo => {
+    manager.echo = Echo;
+    manager.boot();
+});
+
 Statamic.$events.$on('publish-container-created', container => {
     if (!container.reference) return;
     manager.addWorkspace(container);
@@ -17,9 +22,4 @@ Statamic.$events.$on('publish-container-created', container => {
 Statamic.$events.$on('publish-container-destroyed', container => {
     if (!manager.workspaces[container.name]) return;
     manager.destroyWorkspace(container);
-});
-
-Statamic.$echo.booted(Echo => {
-    manager.echo = Echo;
-    manager.boot();
 });

--- a/resources/js/store.js
+++ b/resources/js/store.js
@@ -1,0 +1,20 @@
+export function useCollaborationStore(channelName) {
+    const useStore = Statamic.$pinia.defineStore(`collaboration/${channelName}`, {
+        state: () => ({
+            users: [],
+        }),
+        actions: {
+            setUsers(users) {
+                this.users = users;
+            },
+            addUser(user) {
+                this.users.push(user);
+            },
+            removeUser(removedUser) {
+                this.users = this.users.filter(user => user.id !== removedUser.id);
+            },
+        },
+    });
+
+    return useStore();
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,10 +1,11 @@
 import { defineConfig } from 'vite';
 import laravel from 'laravel-vite-plugin';
-import vue from '@vitejs/plugin-vue2';
+import statamic from '@statamic/cms/vite-plugin';
 
 export default defineConfig({
     base: '/vendor/collaboration/build',
     plugins: [
+        statamic(),
         laravel({
             input: [
                 'resources/js/collaboration.js'
@@ -13,6 +14,5 @@ export default defineConfig({
             publicDirectory: 'resources/dist',
             hotFile: 'resources/dist/hot',
         }),
-        vue(),
-    ],
+    ]
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,6 +7,7 @@ export default defineConfig({
     plugins: [
         statamic(),
         laravel({
+            valetTls: "sandbox.test",
             input: [
                 'resources/js/collaboration.js'
             ],

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,7 +7,6 @@ export default defineConfig({
     plugins: [
         statamic(),
         laravel({
-            valetTls: "sandbox.test",
             input: [
                 'resources/js/collaboration.js'
             ],


### PR DESCRIPTION
Closes #109
Depends on https://github.com/statamic/cms/pull/13974

## Summary

Adds compatibility with Statamic 6, which moved the publish form to Vue 3 with the Composition API and Pinia.

## Changes

- **Build/deps:** Vite 8, updated dependencies, npm audit fixes, adjusted `vite.config.js`, `composer.json` constraints bumped for Statamic 6.
- **Field focus & locking:** Field lock state lives in the container's reactive `fieldFocus` ref. The Workspace calls the container's `focusField(handle, user)` / `blurField(handle, user)` to update it, and watches it for local-user changes to broadcast focus/blur whispers.
- **State store:** Pinia replaces Vuex. Extracted into `resources/js/store.js` so the `StatusBar` and `Workspace` don't redefine it.
- **Values & meta:** Read from / write to the container's `values` and `meta` refs via `setValues`, `setFieldValue`, `setMeta`, `setFieldMeta` instead of dispatching to the Vuex `publish` module. Meta is still cleaned through `cleanEntireMetaPayload` / `cleanMetaPayload` and merged on apply.
- **Misc:** Reuse Statamic's `debounce` util, status bar tweaks.

## Test plan

- [x] Open the same entry as two users — focusing a field shows the other user's avatar and locks the field.
- [x] Typing in a field syncs to the other user (debounced).
- [x] Force-unlock from the status bar dropdown works.
- [x] Saving / publishing / restoring a revision shows the correct toast / blocking notification.
- [x] Joining mid-session restores values, meta, and current focus state.
- [x] Navigating away (SPA + full reload) properly leaves the channel.