### PR TITLE
Improve debugging

### DIFF
--- a/resources/js/StatusBar.vue
+++ b/resources/js/StatusBar.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed } from 'vue';
+import { computed, ref, watch, onUnmounted } from 'vue';
 import { Icon, Dropdown, DropdownMenu, DropdownItem, Avatar } from '@statamic/cms/ui';
 import { useCollaborationStore } from './store';
 
@@ -15,13 +15,31 @@ const props = defineProps({
 const store = useCollaborationStore(props.channelName);
 const users = computed(() => store.users);
 const connecting = computed(() => store.users.length === 0);
+const takingLong = ref(false);
+let takingLongTimer = null;
+
+watch(connecting, (isConnecting) => {
+    clearTimeout(takingLongTimer);
+    if (isConnecting) {
+        takingLongTimer = setTimeout(() => takingLong.value = true, 5000);
+    } else {
+        takingLong.value = false;
+    }
+}, { immediate: true });
+
+onUnmounted(() => clearTimeout(takingLongTimer));
 </script>
 
 <template>
     <div class="collaboration-status-bar relative -top-[1.25rem]" v-if="connecting || users.length > 1">
         <div v-if="connecting" class="flex items-center text-sm text-gray-500 dark:text-gray-400">
             <Icon name="loading" class="me-1.5 size-3.5 animate-spin" />
-            {{ __('Attempting websocket connection...') }}
+            <template v-if="takingLong">
+                {{ __('Connection taking longer than expected. Check the browser console for details.') }}
+            </template>
+            <template v-else>
+                {{ __('Attempting websocket connection...') }}
+            </template>
         </div>
         <div v-if="users.length > 1" class="flex items-center -space-x-2">
             <Dropdown v-for="(user, index) in users" :key="user.id">

--- a/resources/js/Workspace.js
+++ b/resources/js/Workspace.js
@@ -3,6 +3,7 @@ import { debounce } from '@statamic/cms';
 import buddyIn from '../audio/buddy-in.wav'
 import buddyOut from '../audio/buddy-out.wav'
 import { useCollaborationStore } from './store';
+import { debug, error } from './logger';
 
 export default class Workspace {
 
@@ -60,7 +61,7 @@ export default class Workspace {
         const reference = this.container.reference.replaceAll('::', '.');
         this.channelName = `${reference}.${this.container.site.replaceAll('.', '_')}`;
 
-        this.debug(`Joining channel "${this.channelName}"`);
+        debug(`Joining channel "${this.channelName}"`);
         this.channel = this.echo.join(this.channelName);
 
         const clearSubscribeTimeout = () => {
@@ -71,18 +72,18 @@ export default class Workspace {
         };
 
         this.subscribeTimeout = setTimeout(() => {
-            this.debug(`⏳ Still waiting to subscribe to "${this.channelName}" — is your broadcast server running and reachable?`);
+            debug(`⏳ Still waiting to subscribe to "${this.channelName}" — is your broadcast server running and reachable?`);
             this.subscribeTimeout = null;
         }, 5000);
 
         this.channel
             .subscribed(() => {
                 clearSubscribeTimeout();
-                this.debug(`✅ Subscribed to channel "${this.channelName}"`);
+                debug(`✅ Subscribed to channel "${this.channelName}"`);
             })
-            .error(error => {
+            .error(e => {
                 clearSubscribeTimeout();
-                this.error(`❌ Subscription error on channel "${this.channelName}"`, {error});
+                error(`❌ Subscription error on channel "${this.channelName}"`, {error: e});
             });
 
         this.channel.here(users => {
@@ -125,7 +126,7 @@ export default class Workspace {
 
         this.listenForWhisper(`initialize-state-for-${this.user.id}`, payload => {
             if (this.initialStateUpdated) return;
-            this.debug('✅ Applying broadcasted state change', payload);
+            debug('✅ Applying broadcasted state change', payload);
             this.container.setValues(payload.values);
             this.lastValues = clone(payload.values);
             const restoredMeta = this.restoreEntireMetaPayload(payload.meta || {});
@@ -136,17 +137,17 @@ export default class Workspace {
         });
 
         this.listenForWhisper('focus', ({ user, handle }) => {
-            this.debug(`Heard that user has changed focus`, { user, handle });
+            debug(`Heard that user has changed focus`, { user, handle });
             this.focus(user, handle);
         });
 
         this.listenForWhisper('blur', ({ user, handle }) => {
-            this.debug(`Heard that user has blurred`, { user, handle });
+            debug(`Heard that user has blurred`, { user, handle });
             this.blur(user, handle);
         });
 
         this.listenForWhisper('force-unlock', ({ targetUser, originUser }) => {
-            this.debug(`Heard that user has requested another be unlocked`, { targetUser, originUser });
+            debug(`Heard that user has requested another be unlocked`, { targetUser, originUser });
 
             if (targetUser.id !== this.user.id) return;
 
@@ -290,12 +291,12 @@ export default class Workspace {
     }
 
     rememberValueChange(handle, value) {
-        this.debug('Remembering value change', { handle, value });
+        debug('Remembering value change', { handle, value });
         this.lastValues[handle] = clone(value);
     }
 
     rememberMetaChange(handle, value) {
-        this.debug('Remembering meta change', { handle, value });
+        debug('Remembering meta change', { handle, value });
         this.lastMetaValues[handle] = clone(value);
     }
 
@@ -380,24 +381,16 @@ export default class Workspace {
     }
 
     applyBroadcastedValueChange(payload) {
-        this.debug('✅ Applying broadcasted value change', payload);
+        debug('✅ Applying broadcasted value change', payload);
         this.rememberValueChange(payload.handle, payload.value);
         this.container.setFieldValue(payload.handle, payload.value);
     }
 
     applyBroadcastedMetaChange(payload) {
-        this.debug('✅ Applying broadcasted meta change', payload);
+        debug('✅ Applying broadcasted meta change', payload);
         let value = { ...this.lastMetaValues[payload.handle], ...payload.value };
         this.rememberMetaChange(payload.handle, value);
         this.container.setFieldMeta(payload.handle, value);
-    }
-
-    debug(message, args) {
-        console.log('[Collaboration]', message, {...args});
-    }
-
-    error(message, args) {
-        console.error('[Collaboration]', message, {...args});
     }
 
     isAlone() {
@@ -412,7 +405,7 @@ export default class Workspace {
         const msgId = Math.random() + '';
 
         if (str.length < chunkSize) {
-            this.debug(`📣 Broadcasting "${event}"`, payload);
+            debug(`📣 Broadcasting "${event}"`, payload);
             this.channel.whisper(event, payload);
             return;
         }
@@ -426,7 +419,7 @@ export default class Workspace {
                 chunk: str.substr(i * chunkSize, chunkSize),
                 final: chunkSize * (i + 1) >= str.length
             };
-            this.debug(`📣 Broadcasting "${event}"`, chunk);
+            debug(`📣 Broadcasting "${event}"`, chunk);
             this.channel.whisper(event, chunk);
         }
     }

--- a/resources/js/Workspace.js
+++ b/resources/js/Workspace.js
@@ -54,7 +54,13 @@ export default class Workspace {
     initializeEcho() {
         const reference = this.container.reference.replaceAll('::', '.');
         this.channelName = `${reference}.${this.container.site.replaceAll('.', '_')}`;
+
+        this.debug(`Joining channel "${this.channelName}"`);
         this.channel = this.echo.join(this.channelName);
+
+        this.channel
+            .subscribed(() => this.debug(`✅ Subscribed to channel "${this.channelName}"`))
+            .error(error => this.debug(`❌ Subscription error on channel "${this.channelName}"`, {error}));
 
         this.channel.here(users => {
             this.initializeValueWatcher();

--- a/resources/js/Workspace.js
+++ b/resources/js/Workspace.js
@@ -21,6 +21,7 @@ export default class Workspace {
         this.debouncedBroadcastValueChangeFuncsByHandle = {};
         this.debouncedBroadcastMetaChangeFuncsByHandle = {};
         this.focusWatcher = null;
+        this.subscribeTimeout = null;
     }
 
     start() {
@@ -48,6 +49,10 @@ export default class Workspace {
             this.focusWatcher();
             this.focusWatcher = null;
         }
+        if (this.subscribeTimeout) {
+            clearTimeout(this.subscribeTimeout);
+            this.subscribeTimeout = null;
+        }
         this.echo.leave(this.channelName);
     }
 
@@ -58,9 +63,27 @@ export default class Workspace {
         this.debug(`Joining channel "${this.channelName}"`);
         this.channel = this.echo.join(this.channelName);
 
+        const clearSubscribeTimeout = () => {
+            if (this.subscribeTimeout) {
+                clearTimeout(this.subscribeTimeout);
+                this.subscribeTimeout = null;
+            }
+        };
+
+        this.subscribeTimeout = setTimeout(() => {
+            this.debug(`⏳ Still waiting to subscribe to "${this.channelName}" — is your broadcast server running and reachable?`);
+            this.subscribeTimeout = null;
+        }, 5000);
+
         this.channel
-            .subscribed(() => this.debug(`✅ Subscribed to channel "${this.channelName}"`))
-            .error(error => this.debug(`❌ Subscription error on channel "${this.channelName}"`, {error}));
+            .subscribed(() => {
+                clearSubscribeTimeout();
+                this.debug(`✅ Subscribed to channel "${this.channelName}"`);
+            })
+            .error(error => {
+                clearSubscribeTimeout();
+                this.debug(`❌ Subscription error on channel "${this.channelName}"`, {error});
+            });
 
         this.channel.here(users => {
             this.initializeValueWatcher();

--- a/resources/js/Workspace.js
+++ b/resources/js/Workspace.js
@@ -82,7 +82,7 @@ export default class Workspace {
             })
             .error(error => {
                 clearSubscribeTimeout();
-                this.debug(`❌ Subscription error on channel "${this.channelName}"`, {error});
+                this.error(`❌ Subscription error on channel "${this.channelName}"`, {error});
             });
 
         this.channel.here(users => {
@@ -394,6 +394,10 @@ export default class Workspace {
 
     debug(message, args) {
         console.log('[Collaboration]', message, {...args});
+    }
+
+    error(message, args) {
+        console.error('[Collaboration]', message, {...args});
     }
 
     isAlone() {

--- a/resources/js/collaboration.js
+++ b/resources/js/collaboration.js
@@ -2,6 +2,7 @@ import '../css/cp.css';
 import Manager from './Manager';
 import StatusBar from './StatusBar.vue';
 import BlockingNotification from './BlockingNotification.vue';
+import { debug, error } from './logger';
 const manager = new Manager;
 
 Statamic.booting(() => {
@@ -18,9 +19,9 @@ Statamic.$echo.booted(Echo => {
     // Echo here is Statamic's wrapper; the underlying Laravel Echo is at Echo.echo.
     const connection = Echo.echo?.connector?.pusher?.connection;
     if (connection) {
-        console.log('[Collaboration] Connection state:', connection.state);
-        connection.bind('state_change', ({ previous, current }) => console.log(`[Collaboration] Connection state: ${previous} → ${current}`));
-        connection.bind('error', error => console.error('[Collaboration] Connection error:', error));
+        debug('Connection state:', connection.state);
+        connection.bind('state_change', ({ previous, current }) => debug(`Connection state: ${previous} → ${current}`));
+        connection.bind('error', e => error('Connection error:', e));
     }
 });
 

--- a/resources/js/collaboration.js
+++ b/resources/js/collaboration.js
@@ -12,6 +12,16 @@ Statamic.booting(() => {
 Statamic.$echo.booted(Echo => {
     manager.echo = Echo;
     manager.boot();
+
+    // When using Pusher or Reverb (both pusher-js under the hood), log connection
+    // state transitions to help diagnose why the websocket isn't connecting.
+    // Echo here is Statamic's wrapper; the underlying Laravel Echo is at Echo.echo.
+    const connection = Echo.echo?.connector?.pusher?.connection;
+    if (connection) {
+        console.log('[Collaboration] Connection state:', connection.state);
+        connection.bind('state_change', ({ previous, current }) => console.log(`[Collaboration] Connection state: ${previous} → ${current}`));
+        connection.bind('error', error => console.log('[Collaboration] Connection error:', error));
+    }
 });
 
 Statamic.$events.$on('publish-container-created', container => {

--- a/resources/js/collaboration.js
+++ b/resources/js/collaboration.js
@@ -20,7 +20,7 @@ Statamic.$echo.booted(Echo => {
     if (connection) {
         console.log('[Collaboration] Connection state:', connection.state);
         connection.bind('state_change', ({ previous, current }) => console.log(`[Collaboration] Connection state: ${previous} → ${current}`));
-        connection.bind('error', error => console.log('[Collaboration] Connection error:', error));
+        connection.bind('error', error => console.error('[Collaboration] Connection error:', error));
     }
 });
 

--- a/resources/js/logger.js
+++ b/resources/js/logger.js
@@ -1,0 +1,2 @@
+export const debug = (message, ...args) => console.log('[Collaboration]', message, ...args);
+export const error = (message, ...args) => console.error('[Collaboration]', message, ...args);


### PR DESCRIPTION
Adds visibility into why the Collaboration addon's websocket isn't connecting. Previously, a misconfigured broadcast setup (wrong Pusher cluster, unreachable Reverb server, etc.) would leave the "Attempting websocket connection…" banner stuck with zero signal in the console or UI.

- Logs channel-level events: `echo.join`, `channel.subscribed`, `channel.error`.
- Logs pusher-js connection state transitions and errors (feature-gated on `Echo.echo.connector.pusher.connection`, so non-pusher-js drivers are unaffected).
- After 5 seconds of waiting, logs a "still waiting — is your broadcast server running and reachable?" hint, and swaps the status bar banner to "Taking longer than expected. Check the browser console for details." so non-devs get a signal to go look.
- Uses `console.error` for the error paths so they stand out.
- Extracts a small `logger.js` module (`debug` / `error`) so the `[Collaboration]` prefix lives in one place.