### PR TITLE
Fix asset editors crashing when the container has no site

### DIFF
--- a/resources/js/Workspace.js
+++ b/resources/js/Workspace.js
@@ -102,7 +102,10 @@ export default class Workspace {
 
     initializeEcho() {
         const reference = this.container.reference.value.replaceAll('::', '.');
-        this.channelName = `${reference}.${this.container.site.value.replaceAll('.', '_')}`;
+        // Assets aren't site-scoped, so their publish container has no site.
+        // Fall back to a site-less channel instead of throwing on `.replaceAll`.
+        const site = this.container.site?.value;
+        this.channelName = site ? `${reference}.${site.replaceAll('.', '_')}` : reference;
 
         const channelName = this.channelName;
         debug(`Joining channel "${channelName}"`);


### PR DESCRIPTION
## Problem

On Statamic 6, opening **any asset editor** throws and the editor's fields never render:

```
Uncaught (in promise) TypeError: can't access property "replaceAll", this.container.site.value is undefined
```

Assets aren't site-scoped, so the asset publish container has no `site`. `Workspace.initializeEcho()` builds the channel name as:

```js
this.channelName = `${reference}.${this.container.site.value.replaceAll('.', '_')}`;
```

`container.site.value` is `undefined` for assets → `.replaceAll` throws during workspace init (a mounted hook), aborting the editor render. Reproduces on every asset container in a single-site install.

## Fix

Build the channel without the site segment when no site is present (and use optional chaining). Entries/terms (which have a site) are unchanged; assets now get a stable, site-less presence channel keyed by their reference instead of crashing.

```js
const reference = this.container.reference.value.replaceAll('::', '.');
const site = this.container.site?.value;
this.channelName = site ? `${reference}.${site.replaceAll('.', '_')}` : reference;
```

Fixes #126.